### PR TITLE
chore: bump all programs to 2025.3.1

### DIFF
--- a/pkgs/advantagescope/default.nix
+++ b/pkgs/advantagescope/default.nix
@@ -2,17 +2,17 @@
 
 let
   pname = "advantagescope";
-  version = "4.1.1";
+  version = "4.1.2";
 
   src = {
     x86_64-linux = fetchurl {
       url = "https://github.com/Mechanical-Advantage/AdvantageScope/releases/download/v${version}/advantagescope-linux-x64-v${version}.AppImage";
-      hash = "sha256-LkvB7WulNvbEN7LYpqRIme2EwhVuqf5bQY7ivNA/o44=";
+      hash = "sha256-c76rWZBPbx4jjEFgn/diakzgFGNB98oWr3kkqIDgFq8=";
     };
 
     aarch64-linux = fetchurl {
       url = "https://github.com/Mechanical-Advantage/AdvantageScope/releases/download/v${version}/advantagescope-linux-arm64-v${version}.AppImage";
-      hash = "sha256-O/3Pcp2XO89xeiSYFR6jv9neqrKHw9H4nyB+gxVbbLM=";
+      hash = "sha256-ysMlJxEChg3RsZwOEIwDp6qqi5ZSwglNm4bv0StyIiM=";
     };
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 

--- a/pkgs/choreo/default.nix
+++ b/pkgs/choreo/default.nix
@@ -2,11 +2,11 @@
 
 let
   pname = "choreo";
-  version = "2024.2.3";
+  version = "2025.0.3";
 
   src = fetchurl {
     url = "https://github.com/SleipnirGroup/Choreo/releases/download/v${version}/Choreo-v${version}-Linux-x86_64.AppImage";
-    hash = "sha256-Jwj5PW/Az11aHZFDPkt71WD1QH0xT8NqpYGAJnhjxhM=";
+    hash = "sha256-2XNsZHYDhTvZmMJoXTkzNfystdd4zcpPIxK0XX+hRjQ=";
   };
 
   icon = fetchurl {

--- a/pkgs/choreo/default.nix
+++ b/pkgs/choreo/default.nix
@@ -1,33 +1,69 @@
-{ lib, fetchurl, appimageTools }:
-
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, copyDesktopItems
+, unzip
+, wrapGAppsHook3
+, webkitgtk_4_0
+, makeDesktopItem
+}:
 let
   pname = "choreo";
   version = "2025.0.3";
 
   src = fetchurl {
-    url = "https://github.com/SleipnirGroup/Choreo/releases/download/v${version}/Choreo-v${version}-Linux-x86_64.AppImage";
-    hash = "sha256-2XNsZHYDhTvZmMJoXTkzNfystdd4zcpPIxK0XX+hRjQ=";
+    url = "https://github.com/SleipnirGroup/Choreo/releases/download/v${version}/Choreo-v${version}-Linux-x86_64-standalone.zip";
+    hash = "sha256-sB7en5sPEJfDRBL8CYLCLeTXYp46n3K6qXG4w/w1aZI=";
   };
 
   icon = fetchurl {
-    url = "https://raw.githubusercontent.com/SleipnirGroup/Choreo/v${version}/icon/icon.svg";
+    url = "https://raw.githubusercontent.com/SleipnirGroup/Choreo/v${version}/src-tauri/icons/icon.svg";
     hash = "sha256-HKCzFijS08MKwsMsfTW9ohxWDqyqhRpLhuBjwVWWKPE=";
   };
-
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
-  };
 in
-appimageTools.wrapType2 {
-  inherit pname version src;
+stdenv.mkDerivation {
+  inherit pname;
+  inherit version;
 
-  extraInstallCommands = ''
-    install -D ${icon} $out/share/pixmaps/choreo.svg
-    install -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+  inherit src;
 
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace "Exec=AppRun" "Exec=${pname}"
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    unzip
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    webkitgtk_4_0
+  ];
+
+  sourceRoot = ".";
+  unpackCmd = "unzip \"$src\"";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 ${pname} "$out"/bin/${pname}
+    install -Dm555 ${pname}-cli "$out"/bin/${pname}-cli
+
+    install -Dm444 ${icon} "$out"/share/pixmaps/${pname}.svg
+
+    runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "Choreo";
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = "A graphical tool for planning time-optimized trajectories for autonomous mobile robots in the FIRST Robotics Competition";
+      categories = [ "Development" ];
+      keywords = [ "FRC" "Motion Profile" "Path Planning" ];
+    })
+  ];
 
   meta = with lib; {
     description = "A graphical tool for planning time-optimized trajectories for autonomous mobile robots in the FIRST Robotics Competition";

--- a/pkgs/elastic-dashboard/default.nix
+++ b/pkgs/elastic-dashboard/default.nix
@@ -9,11 +9,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "elastic-dashboard";
-  version = "2025.0.2";
+  version = "2025.1.0";
 
   src = fetchurl {
     url = "https://github.com/Gold872/elastic-dashboard/releases/download/v${version}/Elastic-Linux.zip";
-    hash = "sha256-6bZO9BqAS2aVLYYI+qEgX11ee89GT6lpw4GHZpDukTE=";
+    hash = "sha256-TNqfK6AuKkw1Z+qLfZXD1RD44LrwVWEtEeY63NEVY7Y=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/wpilib/datalogtool.nix
+++ b/pkgs/wpilib/datalogtool.nix
@@ -8,7 +8,7 @@ buildBinTool {
   artifactHashes = {
     linuxarm64 = "sha256-dzKMrAXlWf/XVoqr/lKql97hjQ7P6XNb1kEKweLGUWg=";
     linuxarm32 = "sha256-s0OvTPH1AcJdjBmPfln5pfJOmlNA0WtrdLkj0zT7a2g=";
-    linux86-64 = "sha256-ZsqwQobpNjGt0x1XHAD10T7ZRhyMU2xvrr+kKwY2IH4=";
+    linuxx86-64 = "sha256-ZsqwQobpNjGt0x1XHAD10T7ZRhyMU2xvrr+kKwY2IH4=";
     osxuniversal = "sha256-wK5ACryYDANGqMGgweQ2ygfi/3ZsdiTH0PmNTkrkB4Q=";
   };
 

--- a/pkgs/wpilib/datalogtool.nix
+++ b/pkgs/wpilib/datalogtool.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "DataLogTool";
 
   artifactHashes = {
-    linuxarm32 = "sha256-pu+SGfje/C8eAfY7HilYdS71+HBHmencTVKNDSJWZE4=";
-    linuxarm64 = "sha256-kzusvOqiFv8vaFUtih5tr/ae2TH+yt/vml2IIDydFyU=";
-    linuxx86-64 = "sha256-+cI8N/8ZTe9YD62WXqZu0Z0OzDL3wQ1isFCCUroG2vI=";
-    osxuniversal = "sha256-oLZeDZD5SXA6gdt8sHVeWkH2xwiWzwhJO4dXX5Yfo/w=";
+    linuxarm64 = "sha256-dzKMrAXlWf/XVoqr/lKql97hjQ7P6XNb1kEKweLGUWg=";
+    linuxarm32 = "sha256-s0OvTPH1AcJdjBmPfln5pfJOmlNA0WtrdLkj0zT7a2g=";
+    linux86-64 = "sha256-ZsqwQobpNjGt0x1XHAD10T7ZRhyMU2xvrr+kKwY2IH4=";
+    osxuniversal = "sha256-wK5ACryYDANGqMGgweQ2ygfi/3ZsdiTH0PmNTkrkB4Q=";
   };
 
   iconPng = "${allwpilibSources}/datalogtool/src/main/native/resources/dlt-512.png";

--- a/pkgs/wpilib/datalogtool.nix
+++ b/pkgs/wpilib/datalogtool.nix
@@ -6,8 +6,8 @@ buildBinTool {
   name = "DataLogTool";
 
   artifactHashes = {
-    linuxarm64 = "sha256-dzKMrAXlWf/XVoqr/lKql97hjQ7P6XNb1kEKweLGUWg=";
     linuxarm32 = "sha256-s0OvTPH1AcJdjBmPfln5pfJOmlNA0WtrdLkj0zT7a2g=";
+    linuxarm64 = "sha256-dzKMrAXlWf/XVoqr/lKql97hjQ7P6XNb1kEKweLGUWg=";
     linuxx86-64 = "sha256-ZsqwQobpNjGt0x1XHAD10T7ZRhyMU2xvrr+kKwY2IH4=";
     osxuniversal = "sha256-wK5ACryYDANGqMGgweQ2ygfi/3ZsdiTH0PmNTkrkB4Q=";
   };

--- a/pkgs/wpilib/default.nix
+++ b/pkgs/wpilib/default.nix
@@ -4,9 +4,9 @@ lib.makeScope pkgs.newScope (self: with self; {
   allwpilibSources = fetchFromGitHub rec {
     passthru = {
       branch = "release";
-      version = "2025.2.1";
-      java.version = "2025.2.1";
-      native.version = "2025.2.1";
+      version = "2025.3.1";
+      java.version = "2025.3.1";
+      native.version = "2025.3.1";
     };
 
     owner = "wpilibsuite";

--- a/pkgs/wpilib/default.nix
+++ b/pkgs/wpilib/default.nix
@@ -12,7 +12,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     owner = "wpilibsuite";
     repo = "allwpilib";
     rev = "v${passthru.version}";
-    hash = "sha256-9GgyfIOvQKHrj4Fq4M1aBh8xvBfFV3x/K1rAuQ0DYDg=";
+    hash = "sha256-NX4QEDo5n+YXUEx5prMiUcQsB45bZefh3ODuoZN1pB0=";
   };
 
   buildBinTool = callPackage ./build-bin-tool.nix { };

--- a/pkgs/wpilib/glass.nix
+++ b/pkgs/wpilib/glass.nix
@@ -7,7 +7,7 @@ buildBinTool {
 
   artifactHashes = {
     linuxarm32 = "sha256-JLNucSwiAtLCV+IXKchx9PVkYEEMLgnLMlvD9YoCDe0=";
-    linux86-64 = "sha256-WSaCCcQlKoJ8prNLqNUlBZhIOvpynUzwV6CYNtameJw=";
+    linuxx86-64 = "sha256-WSaCCcQlKoJ8prNLqNUlBZhIOvpynUzwV6CYNtameJw=";
     linuxarm64 = "sha256-T3Pc4NWK7rTN5V0hobUqq2c1lxxACai3vcWLWMHV/ME=";
     osxuniversal = "sha256-cXP40rpfDtQPsDFrdtBB7d9YfxywCol6ec9ccJZgkt0=";
   };

--- a/pkgs/wpilib/glass.nix
+++ b/pkgs/wpilib/glass.nix
@@ -7,8 +7,8 @@ buildBinTool {
 
   artifactHashes = {
     linuxarm32 = "sha256-JLNucSwiAtLCV+IXKchx9PVkYEEMLgnLMlvD9YoCDe0=";
-    linuxx86-64 = "sha256-WSaCCcQlKoJ8prNLqNUlBZhIOvpynUzwV6CYNtameJw=";
     linuxarm64 = "sha256-T3Pc4NWK7rTN5V0hobUqq2c1lxxACai3vcWLWMHV/ME=";
+    linuxx86-64 = "sha256-WSaCCcQlKoJ8prNLqNUlBZhIOvpynUzwV6CYNtameJw=";
     osxuniversal = "sha256-cXP40rpfDtQPsDFrdtBB7d9YfxywCol6ec9ccJZgkt0=";
   };
 

--- a/pkgs/wpilib/glass.nix
+++ b/pkgs/wpilib/glass.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "Glass";
 
   artifactHashes = {
-    linuxarm32 = "sha256-O8Xw9SM91zoNUwEbTpFrvLNSlAxMjcvrGpTEXAS5iuQ=";
-    linuxarm64 = "sha256-jVyuTwz0mx2iOqZgFil5pCnujo9wKq2PwqflBVr5dok=";
-    linuxx86-64 = "sha256-zncOGo3gQuBIznoD0nFrIs/nUe0dxG7suwBXuOmRS8Y=";
-    osxuniversal = "sha256-4ntI76PyL3gKJqZHPKTZ7So9u2xjRl3WF5YfeGvkEz4=";
+    linuxarm32 = "sha256-JLNucSwiAtLCV+IXKchx9PVkYEEMLgnLMlvD9YoCDe0=";
+    linux86-64 = "sha256-WSaCCcQlKoJ8prNLqNUlBZhIOvpynUzwV6CYNtameJw=";
+    linuxarm64 = "sha256-T3Pc4NWK7rTN5V0hobUqq2c1lxxACai3vcWLWMHV/ME=";
+    osxuniversal = "sha256-cXP40rpfDtQPsDFrdtBB7d9YfxywCol6ec9ccJZgkt0=";
   };
 
   iconPng = "${allwpilibSources}/glass/src/app/native/resources/glass-512.png";

--- a/pkgs/wpilib/outlineviewer.nix
+++ b/pkgs/wpilib/outlineviewer.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "OutlineViewer";
 
   artifactHashes = {
-    osxuniversal = "sha256-M9utQrpVLVxbULbl0EFQr6UjDhjNbQcVHv4ZSQExKEc=";
     linuxarm32 = "sha256-PeKUVXcN7khGUAfu3cuHYhFx4hRnyJ2Iyhj2cFtgzjw=";
-    linuxx86-64 = "sha256-ALjDyqGhH6BPCyALAgG9W1AaEiaWbnA1PmVZHlTQynE=";
     linuxarm64 = "sha256-lYTASVzKm2MH/qWSNYJ7UanCIuD9CdxMj69ckbUP7Jg=";
+    linuxx86-64 = "sha256-ALjDyqGhH6BPCyALAgG9W1AaEiaWbnA1PmVZHlTQynE=";
+    osxuniversal = "sha256-M9utQrpVLVxbULbl0EFQr6UjDhjNbQcVHv4ZSQExKEc=";
   };
 
   iconPng = "${allwpilibSources}/outlineviewer/src/main/native/resources/ov-512.png";

--- a/pkgs/wpilib/outlineviewer.nix
+++ b/pkgs/wpilib/outlineviewer.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "OutlineViewer";
 
   artifactHashes = {
-    linuxarm32 = "sha256-8RM/VaeRnuD9ttYEEJMnRQ9NKDa5M/7dyCUIVOwl//E=";
-    linuxarm64 = "sha256-ZTh8/hzhKwyAznsQK/QhBAeMPoBupyBQcqsPcO8tfl0=";
-    linuxx86-64 = "sha256-ZSLNaG+YFALYHcsSF99vXGiaBNLtwR2O6muAwUj6vrc=";
-    osxuniversal = "sha256-P2jC0/27Qe9bYgj32Ce0trjsbRxvxdH642XJdsUbIh0=";
+    osxuniversal = "sha256-M9utQrpVLVxbULbl0EFQr6UjDhjNbQcVHv4ZSQExKEc=";
+    linuxarm32 = "sha256-PeKUVXcN7khGUAfu3cuHYhFx4hRnyJ2Iyhj2cFtgzjw=";
+    linux86-64 = "sha256-ALjDyqGhH6BPCyALAgG9W1AaEiaWbnA1PmVZHlTQynE=";
+    linuxarm64 = "sha256-lYTASVzKm2MH/qWSNYJ7UanCIuD9CdxMj69ckbUP7Jg=";
   };
 
   iconPng = "${allwpilibSources}/outlineviewer/src/main/native/resources/ov-512.png";

--- a/pkgs/wpilib/outlineviewer.nix
+++ b/pkgs/wpilib/outlineviewer.nix
@@ -8,7 +8,7 @@ buildBinTool {
   artifactHashes = {
     osxuniversal = "sha256-M9utQrpVLVxbULbl0EFQr6UjDhjNbQcVHv4ZSQExKEc=";
     linuxarm32 = "sha256-PeKUVXcN7khGUAfu3cuHYhFx4hRnyJ2Iyhj2cFtgzjw=";
-    linux86-64 = "sha256-ALjDyqGhH6BPCyALAgG9W1AaEiaWbnA1PmVZHlTQynE=";
+    linuxx86-64 = "sha256-ALjDyqGhH6BPCyALAgG9W1AaEiaWbnA1PmVZHlTQynE=";
     linuxarm64 = "sha256-lYTASVzKm2MH/qWSNYJ7UanCIuD9CdxMj69ckbUP7Jg=";
   };
 

--- a/pkgs/wpilib/pathweaver.nix
+++ b/pkgs/wpilib/pathweaver.nix
@@ -6,12 +6,11 @@ buildJavaTool {
   name = "PathWeaver";
 
   artifactHashes = {
-    linuxx64 = "sha256-Dv4XuW0oBEsITuy+7khQ/YZCc/Zu7utS5wIU32JZ8Qw=";
     linuxarm32 = "sha256-OmC58BByaouCVt4W9hFPjcN/DY6S6liIy0wSlDsWLbs=";
-    winx64 = "sha256-rMFlvrPPCy+VYb8EnMDX2p5bvwCygs/LU95ACGbX3Cg=";
     linuxarm64 = "sha256-O4QLvvXYRysE3vz7Kl9qnkKtY7sSg3BUUqkh0ebJgLY=";
-    macx64 = "sha256-O8vKuZaAJ/YgxMxZy/uSfkwhwfz74Lmcz8Iu1UlNhLg=";
+    linuxx64 = "sha256-Dv4XuW0oBEsITuy+7khQ/YZCc/Zu7utS5wIU32JZ8Qw=";
     macarm64 = "sha256-T9g5VnJbsaXXsNZCJYq3hSdxK+IxCuWEIpK2oJqL+H0=";
+    macx64 = "sha256-O8vKuZaAJ/YgxMxZy/uSfkwhwfz74Lmcz8Iu1UlNhLg=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/pathweaver.nix
+++ b/pkgs/wpilib/pathweaver.nix
@@ -6,11 +6,12 @@ buildJavaTool {
   name = "PathWeaver";
 
   artifactHashes = {
-    linuxarm32 = "sha256-tU/iEh9yujt7wFONXd653Bdw6vsEycYB0IRKNI5NJNs=";
-    linuxarm64 = "sha256-fTR10SPG6sIn25pMUleT3hl7B7n/qwCWzb4pqK0Gt4Q=";
-    linuxx64 = "sha256-HNweJjTROLU6m0gSSW6zVwCIY/fW7nyOmQJmZNGrBkA=";
-    macarm64 = "sha256-z4g1T0ySyPQ2yCotmiFo5s2maDvrjEDHc+irMR3dJB8=";
-    macx64 = "sha256-bTWYntsnXI+PjyzFukFuL5skNIgUy5xg7FdquQqcm9k=";
+    linuxx64 = "sha256-Dv4XuW0oBEsITuy+7khQ/YZCc/Zu7utS5wIU32JZ8Qw=";
+    linuxarm32 = "sha256-OmC58BByaouCVt4W9hFPjcN/DY6S6liIy0wSlDsWLbs=";
+    winx64 = "sha256-rMFlvrPPCy+VYb8EnMDX2p5bvwCygs/LU95ACGbX3Cg=";
+    linuxarm64 = "sha256-O4QLvvXYRysE3vz7Kl9qnkKtY7sSg3BUUqkh0ebJgLY=";
+    macx64 = "sha256-O8vKuZaAJ/YgxMxZy/uSfkwhwfz74Lmcz8Iu1UlNhLg=";
+    macarm64 = "sha256-T9g5VnJbsaXXsNZCJYq3hSdxK+IxCuWEIpK2oJqL+H0=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/roborioteamnumbersetter.nix
+++ b/pkgs/wpilib/roborioteamnumbersetter.nix
@@ -6,7 +6,7 @@ buildBinTool {
   name = "roboRIOTeamNumberSetter";
 
   artifactHashes = {
-    linux86-64 = "sha256-hUw2bM5iHMtk/g/rGLDUtLUx4BuetYd0FiEjyj50RH8=";
+    linuxx86-64 = "sha256-hUw2bM5iHMtk/g/rGLDUtLUx4BuetYd0FiEjyj50RH8=";
     osxuniversal = "sha256-bbmoYqSr5+VmyrkueEPnYQgGFE9E+fLUcE4PWUZmQjo=";
     linuxarm32 = "sha256-r7AFf9BRXqLy9iNnfjUbAFzKnEvfM8bWv2KABXxb1+E=";
     linuxarm64 = "sha256-tKnFyP8cZnZSxwPkj6ekSlTYAfDPJiJW9Cm024mPhvQ=";

--- a/pkgs/wpilib/roborioteamnumbersetter.nix
+++ b/pkgs/wpilib/roborioteamnumbersetter.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "roboRIOTeamNumberSetter";
 
   artifactHashes = {
-    linuxx86-64 = "sha256-hUw2bM5iHMtk/g/rGLDUtLUx4BuetYd0FiEjyj50RH8=";
-    osxuniversal = "sha256-bbmoYqSr5+VmyrkueEPnYQgGFE9E+fLUcE4PWUZmQjo=";
     linuxarm32 = "sha256-r7AFf9BRXqLy9iNnfjUbAFzKnEvfM8bWv2KABXxb1+E=";
     linuxarm64 = "sha256-tKnFyP8cZnZSxwPkj6ekSlTYAfDPJiJW9Cm024mPhvQ=";
+    linuxx86-64 = "sha256-hUw2bM5iHMtk/g/rGLDUtLUx4BuetYd0FiEjyj50RH8=";
+    osxuniversal = "sha256-bbmoYqSr5+VmyrkueEPnYQgGFE9E+fLUcE4PWUZmQjo=";
   };
 
   extraLibs = [ avahi ];

--- a/pkgs/wpilib/roborioteamnumbersetter.nix
+++ b/pkgs/wpilib/roborioteamnumbersetter.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "roboRIOTeamNumberSetter";
 
   artifactHashes = {
-    linuxarm32 = "sha256-Ui51kCiSTGAqxN0ncJbkYM8MRdddzBIj/ggnuVYW630=";
-    linuxarm64 = "sha256-6LAp0P/tbkjd0Fd9bpwSX0X22XMZ/YgEjoUbiW85Dy0=";
-    linuxx86-64 = "sha256-zzjC+w4JTLQe12MpgC4+Woakr33h9GSzCtU3MdiDbJo=";
-    osxuniversal = "sha256-nJGPZPkzNt9p4G26YQIO59WwFdGEFkMw2HNz3J9vL0s=";
+    linux86-64 = "sha256-hUw2bM5iHMtk/g/rGLDUtLUx4BuetYd0FiEjyj50RH8=";
+    osxuniversal = "sha256-bbmoYqSr5+VmyrkueEPnYQgGFE9E+fLUcE4PWUZmQjo=";
+    linuxarm32 = "sha256-r7AFf9BRXqLy9iNnfjUbAFzKnEvfM8bWv2KABXxb1+E=";
+    linuxarm64 = "sha256-tKnFyP8cZnZSxwPkj6ekSlTYAfDPJiJW9Cm024mPhvQ=";
   };
 
   extraLibs = [ avahi ];

--- a/pkgs/wpilib/robotbuilder.nix
+++ b/pkgs/wpilib/robotbuilder.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://frcmaven.wpi.edu/artifactory/${allwpilibSources.branch}/edu/wpi/first/tools/RobotBuilder/${version}/RobotBuilder-${version}.jar";
-    hash = "sha256-2G+vf49gqQYqkmTDl0GoQCYQdXo9OnzeJlWZ+unW7dA=";
+    hash = "sha256-WfduOZFjEf7SqgaIEVNlGLzyk9KEyI9f2Hu+I4+BFsU=";
   };
 
   dontUnpack = true;

--- a/pkgs/wpilib/shuffleboard.nix
+++ b/pkgs/wpilib/shuffleboard.nix
@@ -6,11 +6,12 @@ buildJavaTool {
   name = "Shuffleboard";
 
   artifactHashes = {
-    linuxarm32 = "sha256-reDsjquo7oHT2HdJwEldJSrrH8Afb+DUcFepWcSdYNw=";
-    linuxarm64 = "sha256-Fa2cZB1GNUt92rKuk3/7WaPK/QaNCSoDSHSaQa7YxBs=";
-    linuxx64 = "sha256-l/rX8XiPdZgChON2/n/L+PgmvWLqolC5TWmmPRPV3Xc=";
-    macarm64 = "sha256-sCseY/lLUcbKiEF3FYyjfOUDQpysC0Mfcenu7gjpQ14=";
-    macx64 = "sha256-VPWnHldcMN1AVrZ2L3j5FW0DhDCBIMtND0qEPzZLNxE=";
+    linuxx64 = "sha256-ar6IqVeqcZKbwv0qm/8fcCapwlmpQDSrT6uT5nn4my8=";
+    macx64 = "sha256-c8BlNZUDvqFx1jzeNE/u8QJbSFoM7TLlcOiYbmCTqVs=";
+    winx64 = "sha256-Z1KjuNEJTlQKF90Avf83zVCAYvyFzkzk9TnEueM/W74=";
+    linuxarm64 = "sha256-UrvL8Ra9BlEapqjGrhTBgxQdkY8E6WaiBqTexUhp5Aw=";
+    linuxarm32 = "sha256-9j/kj1QnNu/Q56B5+tApApRygu7oTJFTdGq7s98u4XQ=";
+    macarm64 = "sha256-NKD6YySg0ZYCZD2Pqvq76BrwVZ9YP+LIhb010AoBxLI=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/shuffleboard.nix
+++ b/pkgs/wpilib/shuffleboard.nix
@@ -6,12 +6,11 @@ buildJavaTool {
   name = "Shuffleboard";
 
   artifactHashes = {
-    linuxx64 = "sha256-ar6IqVeqcZKbwv0qm/8fcCapwlmpQDSrT6uT5nn4my8=";
-    macx64 = "sha256-c8BlNZUDvqFx1jzeNE/u8QJbSFoM7TLlcOiYbmCTqVs=";
-    winx64 = "sha256-Z1KjuNEJTlQKF90Avf83zVCAYvyFzkzk9TnEueM/W74=";
-    linuxarm64 = "sha256-UrvL8Ra9BlEapqjGrhTBgxQdkY8E6WaiBqTexUhp5Aw=";
     linuxarm32 = "sha256-9j/kj1QnNu/Q56B5+tApApRygu7oTJFTdGq7s98u4XQ=";
+    linuxarm64 = "sha256-UrvL8Ra9BlEapqjGrhTBgxQdkY8E6WaiBqTexUhp5Aw=";
+    linuxx64 = "sha256-ar6IqVeqcZKbwv0qm/8fcCapwlmpQDSrT6uT5nn4my8=";
     macarm64 = "sha256-NKD6YySg0ZYCZD2Pqvq76BrwVZ9YP+LIhb010AoBxLI=";
+    macx64 = "sha256-c8BlNZUDvqFx1jzeNE/u8QJbSFoM7TLlcOiYbmCTqVs=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/smartdashboard.nix
+++ b/pkgs/wpilib/smartdashboard.nix
@@ -6,8 +6,9 @@ buildJavaTool {
   name = "SmartDashboard";
 
   artifactHashes = {
-    linuxx64 = "sha256-M6OIhWTQ6xsZ3NNrYaSFrRHp8ZPkHMEY1qa3JciZpu4=";
-    macx64 = "sha256-rk7qa98BbJOgicD0gREhmHNdamOS7zITwc4V1LmIBtE=";
+    macx64 = "sha256-LOL2pED6zP3weK32I8Es6ZgpJbajP5cbcNxpqJRqhS8=";
+    winx64 = "sha256-SCmHqOUKqJp64MnGweqJmuo0ldwDsFWDH3f5mqD8zMQ=";
+    linuxx64 = "sha256-Q2YqppAbTaZSCBYpOJp3soPiywI0oKdB5+DIYYPoNRI=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/smartdashboard.nix
+++ b/pkgs/wpilib/smartdashboard.nix
@@ -6,9 +6,8 @@ buildJavaTool {
   name = "SmartDashboard";
 
   artifactHashes = {
-    macx64 = "sha256-LOL2pED6zP3weK32I8Es6ZgpJbajP5cbcNxpqJRqhS8=";
-    winx64 = "sha256-SCmHqOUKqJp64MnGweqJmuo0ldwDsFWDH3f5mqD8zMQ=";
     linuxx64 = "sha256-Q2YqppAbTaZSCBYpOJp3soPiywI0oKdB5+DIYYPoNRI=";
+    macx64 = "sha256-LOL2pED6zP3weK32I8Es6ZgpJbajP5cbcNxpqJRqhS8=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/sysid.nix
+++ b/pkgs/wpilib/sysid.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "SysId";
 
   artifactHashes = {
-    linuxarm32 = "sha256-jnLKYLfb+g8kaq1+biZD8XFVq8z5K8alTa8UYvkW8Jw=";
-    linuxarm64 = "sha256-Xd8GBqJV/8KdC0iFwYOIKLcKG9tDccTP4EUYlU+O/Xo=";
-    linuxx86-64 = "sha256-IqdsYb3tLaV55VX1trjp58aLuXMRQrOHjrHqV1tL6M8=";
-    osxuniversal = "sha256-eylhiRuINFiqzEBBSGvijwXmNE7CQtp4UznKB2VBvsM=";
+    linux86-64 = "sha256-eaaGGtWgoLupO7/SReBBK5oh9iXjitMWgons6Gai42g=";
+    linuxarm64 = "sha256-zKoONnHpb3C5KM/HXOPC4FFaSrIt1NrNKXXmdD7EkBM=";
+    linuxarm32 = "sha256-teDwVmX01Gox6Kaa+Moy0vsqp8Ao9BNnwPrxgeN4x4c=";
+    osxuniversal = "sha256-sOUyxybn4RV19KuUqU8lwS0dybndI3SZlpXP/46padY=";
   };
 
   iconPng = "${allwpilibSources}/sysid/src/main/native/resources/sysid-512.png";

--- a/pkgs/wpilib/sysid.nix
+++ b/pkgs/wpilib/sysid.nix
@@ -6,9 +6,9 @@ buildBinTool {
   name = "SysId";
 
   artifactHashes = {
-    linuxx86-64 = "sha256-eaaGGtWgoLupO7/SReBBK5oh9iXjitMWgons6Gai42g=";
-    linuxarm64 = "sha256-zKoONnHpb3C5KM/HXOPC4FFaSrIt1NrNKXXmdD7EkBM=";
     linuxarm32 = "sha256-teDwVmX01Gox6Kaa+Moy0vsqp8Ao9BNnwPrxgeN4x4c=";
+    linuxarm64 = "sha256-zKoONnHpb3C5KM/HXOPC4FFaSrIt1NrNKXXmdD7EkBM=";
+    linuxx86-64 = "sha256-eaaGGtWgoLupO7/SReBBK5oh9iXjitMWgons6Gai42g=";
     osxuniversal = "sha256-sOUyxybn4RV19KuUqU8lwS0dybndI3SZlpXP/46padY=";
   };
 

--- a/pkgs/wpilib/sysid.nix
+++ b/pkgs/wpilib/sysid.nix
@@ -6,7 +6,7 @@ buildBinTool {
   name = "SysId";
 
   artifactHashes = {
-    linux86-64 = "sha256-eaaGGtWgoLupO7/SReBBK5oh9iXjitMWgons6Gai42g=";
+    linuxx86-64 = "sha256-eaaGGtWgoLupO7/SReBBK5oh9iXjitMWgons6Gai42g=";
     linuxarm64 = "sha256-zKoONnHpb3C5KM/HXOPC4FFaSrIt1NrNKXXmdD7EkBM=";
     linuxarm32 = "sha256-teDwVmX01Gox6Kaa+Moy0vsqp8Ao9BNnwPrxgeN4x4c=";
     osxuniversal = "sha256-sOUyxybn4RV19KuUqU8lwS0dybndI3SZlpXP/46padY=";

--- a/pkgs/wpilib/utility.nix
+++ b/pkgs/wpilib/utility.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${version}/wpilibutility-linux.tar.gz";
-    hash = "sha256-PcDI/Vj2ARGCsZTG44SYkGFM7jJtGMWNbAZwsduMhjc=";
+    hash = "sha256-bDeS3qq1GB2ocrTB+yXtE9qFo8OWb5Ue4hZYIysPCXA=";
   };
 
   nativeBuildInputs = [ autoPatchelfHook makeBinaryWrapper wrapGAppsHook3 ];

--- a/pkgs/wpilib/vscode-extension.nix
+++ b/pkgs/wpilib/vscode-extension.nix
@@ -12,7 +12,7 @@ vscode-utils.buildVscodeExtension rec {
 
   src = fetchurl {
     url = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${version}/vscode-wpilib-${version}.vsix";
-    hash = "sha256-+fHRJZIuH//hHcFFytXvDg72yhkBh5QKB8UDSFWJ/gA=";
+    hash = "sha256-Up9UBK5zNLhakDyqLkFge7Qs8DUA9tIfy/M61pcn6P0=";
     # The `*.vsix` file is in the end a simple zip file. Change the extension
     # so that existing `unzip` hooks takes care of the unpacking.
     name = "${name}.zip";

--- a/pkgs/wpilib/wpical.nix
+++ b/pkgs/wpilib/wpical.nix
@@ -6,7 +6,7 @@ buildBinTool {
   name = "wpical";
 
   artifactHashes = {
-    linux86-64 = "sha256-YZC/Hm9FrdQdq17QjOwuvhJP1ZQz74x6x2P8OeQwvxA=";
+    linuxx86-64 = "sha256-YZC/Hm9FrdQdq17QjOwuvhJP1ZQz74x6x2P8OeQwvxA=";
     osxuniversal = "sha256-WrMbkEyCtjmjUN7h/uG/mMG33uIKtAEcPr1u3luKiJg=";
   };
 

--- a/pkgs/wpilib/wpical.nix
+++ b/pkgs/wpilib/wpical.nix
@@ -6,8 +6,8 @@ buildBinTool {
   name = "wpical";
 
   artifactHashes = {
-    linuxx86-64 = "sha256-efdktL1NecGHQ5U6kp8x1/Vg3kJRmOyCZA/35y+EyP8=";
-    osxuniversal = "sha256-L5g43PkPQCip3AFuGoZ21VktQ0rvagNKgEqxDMp6SQw=";
+    linux86-64 = "sha256-YZC/Hm9FrdQdq17QjOwuvhJP1ZQz74x6x2P8OeQwvxA=";
+    osxuniversal = "sha256-WrMbkEyCtjmjUN7h/uG/mMG33uIKtAEcPr1u3luKiJg=";
   };
 
   extraLibs = [ gfortran.cc ];

--- a/scripts/fetch_hashes
+++ b/scripts/fetch_hashes
@@ -11,8 +11,6 @@ native_tools=(
     "SysId"
     "roboRIOTeamNumberSetter"
     "wpical"
-    "wpilibutility"
-    "vscode-extension"
 )
 
 java_tools=(
@@ -22,6 +20,24 @@ java_tools=(
     "RobotBuilder"
 )
 
+github_tools=(
+    "Elastic"
+    "Choreo"
+    "AdvantageScope"
+    "Pathplanner"
+    "wpilibutility"
+    "vscode-extension"
+)
+
+github_versions=(
+    "2025.1.0"
+    "2025.0.3"
+    "4.1.2"
+    "2025.2.2"
+    "2025.3.1"
+    "2025.3.1"
+)
+
 for tool in "${native_tools[@]}"; do
     bun fetch_hashes.ts --tool "$tool" --branch "$branch" --version "$native_version" --type native
     echo
@@ -29,5 +45,12 @@ done
 
 for tool in "${java_tools[@]}"; do
     bun fetch_hashes.ts --tool "$tool" --branch "$branch" --version "$java_version" --type java
+    echo
+done
+
+for i in "${!github_tools[@]}"; do
+    tool="${github_tools[$i]}"
+    version="${github_versions[$i]}"
+    bun fetch_hashes.ts --tool "$tool" --branch "na" --version "$version" --type github
     echo
 done

--- a/scripts/fetch_hashes
+++ b/scripts/fetch_hashes
@@ -11,6 +11,8 @@ native_tools=(
     "SysId"
     "roboRIOTeamNumberSetter"
     "wpical"
+    "wpilibutility"
+    "vscode-extension"
 )
 
 java_tools=(

--- a/scripts/fetch_hashes
+++ b/scripts/fetch_hashes
@@ -27,6 +27,7 @@ github_tools=(
     "Pathplanner"
     "wpilibutility"
     "vscode-extension"
+    "allwpilib"
 )
 
 github_versions=(
@@ -34,6 +35,7 @@ github_versions=(
     "2025.0.3"
     "4.1.2"
     "2025.2.2"
+    "2025.3.1"
     "2025.3.1"
     "2025.3.1"
 )

--- a/scripts/fetch_hashes
+++ b/scripts/fetch_hashes
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 branch="release"
-native_version="2025.2.1"
-java_version="2025.2.1"
+native_version="2025.3.1"
+java_version="2025.3.1"
 
 native_tools=(
     "DataLogTool"
@@ -21,11 +21,11 @@ java_tools=(
 )
 
 for tool in "${native_tools[@]}"; do
-    ./fetch_hashes.clj --tool "$tool" --branch "$branch" --version "$native_version" --type native
+    bun fetch_hashes.ts --tool "$tool" --branch "$branch" --version "$native_version" --type native
     echo
 done
 
 for tool in "${java_tools[@]}"; do
-    ./fetch_hashes.clj --tool "$tool" --branch "$branch" --version "$java_version" --type java
+    bun fetch_hashes.ts --tool "$tool" --branch "$branch" --version "$java_version" --type java
     echo
 done

--- a/scripts/fetch_hashes.sh
+++ b/scripts/fetch_hashes.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S nix shell nixpkgs#bun nixpkgs#nix-prefetch-git --command bash
 
 branch="release"
 native_version="2025.3.1"
@@ -20,24 +20,14 @@ java_tools=(
     "RobotBuilder"
 )
 
-github_tools=(
-    "Elastic"
-    "Choreo"
-    "AdvantageScope"
-    "Pathplanner"
-    "wpilibutility"
-    "vscode-extension"
-    "allwpilib"
-)
-
-github_versions=(
-    "2025.1.0"
-    "2025.0.3"
-    "4.1.2"
-    "2025.2.2"
-    "2025.3.1"
-    "2025.3.1"
-    "2025.3.1"
+declare -rA github_tools=(
+    ["AdvantageScope"]="4.1.2"
+    ["Choreo"]="2025.0.3"
+    ["Elastic"]="2025.1.0"
+    ["PathPlanner"]="2025.2.2"
+    ["allwpilib"]="2025.3.1"
+    ["vscode-extension"]="2025.3.1"
+    ["wpilibutility"]="2025.3.1"
 )
 
 for tool in "${native_tools[@]}"; do
@@ -50,9 +40,8 @@ for tool in "${java_tools[@]}"; do
     echo
 done
 
-for i in "${!github_tools[@]}"; do
-    tool="${github_tools[$i]}"
-    version="${github_versions[$i]}"
-    bun fetch_hashes.ts --tool "$tool" --branch "na" --version "$version" --type github
+for tool in "${!github_tools[@]}"; do
+    version="${github_tools[$tool]}"
+    bun fetch_hashes.ts --tool "$tool" --version "$version" --type github
     echo
 done

--- a/scripts/fetch_hashes.ts
+++ b/scripts/fetch_hashes.ts
@@ -139,7 +139,7 @@ async function fetchHashes() {
         // Extract platform name, handling windowsx86-64 case
         let platform = file.uri.slice(file.uri.lastIndexOf("-") + 1, -4);
         // Special case for windowsx86-64
-        if (file.uri.includes("linuxx86-64")) platform = "linux86-64";
+        if (file.uri.includes("linuxx86-64")) platform = "linuxx86-64";
         else if (tool === "RobotBuilder") platform = "all";
         else if (file.uri.includes("windows")) continue;
 

--- a/scripts/fetch_hashes.ts
+++ b/scripts/fetch_hashes.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from "util";
+
+export interface ProgramResponse {
+  repo: string;
+  path: string;
+  created: Date;
+  createdBy: string;
+  lastModified: Date;
+  modifiedBy: string;
+  lastUpdated: Date;
+  children: File[];
+  uri: string;
+}
+
+export interface File {
+  uri: string;
+  folder: boolean;
+}
+
+export interface FileResponse {
+  repo: string;
+  path: string;
+  created: Date;
+  createdBy: string;
+  lastModified: Date;
+  modifiedBy: string;
+  lastUpdated: Date;
+  downloadUri: string;
+  mimeType: string;
+  size: string;
+  checksums: Checksums;
+  originalChecksums: Checksums;
+  uri: string;
+}
+
+export interface Checksums {
+  sha1: string;
+  md5: string;
+  sha256: string;
+}
+
+async function fetchHashes() {
+  const { values } = parseArgs({
+    options: {
+      tool: { type: "string" },
+      branch: { type: "string" },
+      version: { type: "string" },
+      type: { type: "string" },
+    },
+  });
+
+  const { tool, branch, version } = values;
+
+  const programUrl = `https://frcmaven.wpi.edu/artifactory/api/storage/${branch}/edu/wpi/first/tools/${tool}/${version}`;
+  const programResponse = (await (
+    await fetch(programUrl)
+  ).json()) as ProgramResponse;
+  const files = programResponse.children.filter(
+    (file) => !file.uri.endsWith(".pom"),
+  );
+
+  const hashes: Record<string, string> = {};
+
+  for (const file of files) {
+    const fileUrl = `https://frcmaven.wpi.edu/artifactory/api/storage/${branch}/edu/wpi/first/tools/${tool}/${version}${file.uri}`;
+    const response = await fetch(fileUrl);
+    const data = (await response.json()) as FileResponse;
+
+    // Extract platform name, handling windowsx86-64 case
+    let platform = file.uri.slice(file.uri.lastIndexOf("-") + 1, -4);
+    // Special case for windowsx86-64
+    if (file.uri.includes("windowsx86-64")) {
+      platform = "windowsx86-64";
+    } else if (file.uri.includes("linuxx86-64")) {
+      platform = "linux86-64";
+    } else if (tool === "RobotBuilder") platform = "all";
+    hashes[platform] = data.checksums.sha256;
+  }
+
+  // Format output
+  console.log(`${tool} (${version}):`);
+  console.log("artifactHashes = {");
+  for (const [platform, hash] of Object.entries(hashes)) {
+    console.log(`  ${platform} = "${hash}";`);
+  }
+  console.log("};");
+  console.log();
+}
+
+fetchHashes().catch(console.error);

--- a/scripts/fetch_hashes.ts
+++ b/scripts/fetch_hashes.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { parseArgs } from "util";
-const { execSync } = require("child_process");
+import { execSync } from "child_process";
 
 export interface ProgramResponse {
   repo: string;
@@ -98,7 +98,7 @@ async function fetchHashes() {
 
           break;
         }
-        case "Pathplanner": {
+        case "PathPlanner": {
           try {
             const output = execSync(
               `nix-prefetch-git https://github.com/mjansen4857/pathplanner v${version}`,
@@ -112,7 +112,7 @@ async function fetchHashes() {
             hashes.hash = result.hash;
           } catch (error) {
             console.error(
-              `Error fetching git hash for Pathplanner ${version}:`,
+              `Error fetching git hash for PathPlanner ${version}:`,
               error,
             );
             throw error;

--- a/scripts/fetch_hashes.ts
+++ b/scripts/fetch_hashes.ts
@@ -161,7 +161,7 @@ async function fetchHashes() {
         // Special case for windowsx86-64
         if (file.uri.includes("linuxx86-64")) platform = "linuxx86-64";
         else if (tool === "RobotBuilder") platform = "all";
-        else if (file.uri.includes("windows")) continue;
+        else if (file.uri.includes("windows") || file.uri.includes("win")) continue;
 
         const matches = data.checksums.sha256.match(/.{1,2}/g);
         if (!matches) continue;
@@ -177,7 +177,7 @@ async function fetchHashes() {
   // Format output
   console.log(`${tool} (${version}):`);
   console.log("artifactHashes = {");
-  for (const [platform, hash] of Object.entries(hashes)) {
+  for (const [platform, hash] of Object.entries(hashes).sort()) {
     console.log(`  ${platform} = "${hash}";`);
   }
   console.log("};");

--- a/scripts/fetch_hashes.ts
+++ b/scripts/fetch_hashes.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { parseArgs } from "util";
+const { execSync } = require("child_process");
 
 export interface ProgramResponse {
   repo: string;
@@ -98,8 +99,6 @@ async function fetchHashes() {
           break;
         }
         case "Pathplanner": {
-          const { execSync } = require("child_process");
-
           try {
             const output = execSync(
               `nix-prefetch-git https://github.com/mjansen4857/pathplanner v${version}`,
@@ -114,6 +113,27 @@ async function fetchHashes() {
           } catch (error) {
             console.error(
               `Error fetching git hash for Pathplanner ${version}:`,
+              error,
+            );
+            throw error;
+          }
+          break;
+        }
+        case "allwpilib": {
+          try {
+            const output = execSync(
+              `nix-prefetch-git https://github.com/wpilibsuite/allwpilib v${version}`,
+              { encoding: "utf-8", stdio: "pipe" },
+            );
+
+            // Parse the JSON output from nix-prefetch-git
+            const result = JSON.parse(
+              output.split("\n").slice(0, 12).join("\n"),
+            );
+            hashes.hash = result.hash;
+          } catch (error) {
+            console.error(
+              `Error fetching git hash for allwpilib ${version}:`,
               error,
             );
             throw error;

--- a/scripts/fetch_hashes.ts
+++ b/scripts/fetch_hashes.ts
@@ -71,12 +71,12 @@ async function fetchHashes() {
     // Extract platform name, handling windowsx86-64 case
     let platform = file.uri.slice(file.uri.lastIndexOf("-") + 1, -4);
     // Special case for windowsx86-64
-    if (file.uri.includes("windowsx86-64")) {
-      platform = "windowsx86-64";
-    } else if (file.uri.includes("linuxx86-64")) {
-      platform = "linux86-64";
-    } else if (tool === "RobotBuilder") platform = "all";
-    hashes[platform] = data.checksums.sha256;
+    if (file.uri.includes("linuxx86-64")) platform = "linux86-64";
+    else if (tool === "RobotBuilder") platform = "all";
+    else if (file.uri.includes("windows")) continue;
+
+    hashes[platform] =
+      `sha256-${Buffer.from(data.checksums.sha256, "hex").toString("base64")}`;
   }
 
   // Format output

--- a/scripts/fetch_hashes.ts
+++ b/scripts/fetch_hashes.ts
@@ -79,7 +79,7 @@ async function fetchHashes() {
           break;
         }
         case "Choreo": {
-          const url = `https://github.com/SleipnirGroup/Choreo/releases/download/v${version}/Choreo-v${version}-Linux-x86_64.AppImage`;
+          const url = `https://github.com/SleipnirGroup/Choreo/releases/download/v${version}/Choreo-v${version}-Linux-x86_64-standalone.zip`;
           hashes.linux = await fetchHash(url);
 
           break;


### PR DESCRIPTION
Hi! I updated all the wpilib stuff to `2025.3.1` and bumped everything else that had an update too! I had to make a new script to fetch the hashes as the other one didn't seem to work. The new script keeps the same format and works on all the program's hashes now