### PR TITLE
Use recurseIntoAttrs from lib instead of pkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
         choreo = final.callPackage ./pkgs/choreo { };
         elastic-dashboard = final.callPackage ./pkgs/elastic-dashboard { };
         pathplanner = final.callPackage ./pkgs/pathplanner { };
-        wpilib = final.recurseIntoAttrs (final.callPackage ./pkgs/wpilib { });
+        wpilib = final.lib.recurseIntoAttrs (final.callPackage ./pkgs/wpilib { });
         frc-nix-update = final.callPackage ./pkgs/frc-nix-update { };
 
         vscode-extensions = prev.vscode-extensions // { wpilibsuite.vscode-wpilib = final.wpilib.vscode-wpilib; };


### PR DESCRIPTION
fixes the following warning when using latest nixpkgs:

```console
trace: evaluation warning: 'recurseIntoAttrs' has been removed from pkgs, use `lib.recurseIntoAttrs` instead
```

See:
- https://github.com/NixOS/nixpkgs/blob/10b2374fe32d931515f2b08868d3076142a1b4b7/pkgs/top-level/aliases.nix#L1373
- https://github.com/NixOS/nixpkgs/pull/455775