### PR TITLE
chore: update FRC packages and nixpkgs to latest versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,10 +47,11 @@
         let
           packages = import ./. { inherit pkgs; };
         in
-        lib.attrsets.filterAttrs (_: pkg: 
-          builtins.elem pkgs.stdenv.hostPlatform.system pkg.meta.platforms
-          && !(pkg.meta.broken or false)
-        )
+        lib.attrsets.filterAttrs
+          (_: pkg:
+            builtins.elem pkgs.stdenv.hostPlatform.system pkg.meta.platforms
+            && !(pkg.meta.broken or false)
+          )
           {
             inherit (packages)
               advantagescope

--- a/pkgs/advantagescope/default.nix
+++ b/pkgs/advantagescope/default.nix
@@ -1,15 +1,15 @@
-{
-  lib,
-  buildNpmPackage,
-  fetchFromGitHub,
-  emscripten,
-  electron,
-  libGL,
-  makeWrapper,
-  makeDesktopItem,
-  copyDesktopItems,
-  callPackage,
-  isWPILibVersion ? false,
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, emscripten
+, electron
+, libGL
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+, callPackage
+, isWPILibVersion ? false
+,
 }:
 let
   pname = "advantage-scope";

--- a/pkgs/advantagescope/docs.nix
+++ b/pkgs/advantagescope/docs.nix
@@ -1,9 +1,8 @@
-{
-  buildNpmPackage,
-  src,
-  pname,
-  version,
-  ...
+{ buildNpmPackage
+, src
+, pname
+, version
+, ...
 }:
 buildNpmPackage (finalAttrs: {
   pname = pname + "-docs";

--- a/pkgs/advantagescope/licenses.nix
+++ b/pkgs/advantagescope/licenses.nix
@@ -1,12 +1,11 @@
-{
-  buildNpmPackage,
-  src,
-  pname,
-  version,
-  nodejs,
-  npmDepsHash,
-  cacert,
-  ...
+{ buildNpmPackage
+, src
+, pname
+, version
+, nodejs
+, npmDepsHash
+, cacert
+, ...
 }:
 buildNpmPackage (finalAttrs: {
   pname = pname + "-licenses";

--- a/pkgs/advantagescope/tesseract-lang.nix
+++ b/pkgs/advantagescope/tesseract-lang.nix
@@ -1,12 +1,11 @@
-{
-  buildNpmPackage,
-  src,
-  pname,
-  version,
-  nodejs,
-  npmDepsHash,
-  cacert,
-  ...
+{ buildNpmPackage
+, src
+, pname
+, version
+, nodejs
+, npmDepsHash
+, cacert
+, ...
 }:
 buildNpmPackage (finalAttrs: {
   pname = pname + "-tesseractLang";

--- a/pkgs/elastic-dashboard/default.nix
+++ b/pkgs/elastic-dashboard/default.nix
@@ -9,11 +9,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "elastic-dashboard";
-  version = "null";
+  version = "2026.0.0";
 
   src = fetchurl {
     url = "https://github.com/Gold872/elastic_dashboard/releases/download/v${version}/Elastic-Linux.zip";
-    hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
+    hash = "sha256-Rfn5JbKaE89a+qdJX2yoPlKzuIWOPH5AlAttu7+JtxY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/wpilib/datalogtool.nix
+++ b/pkgs/wpilib/datalogtool.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "DataLogTool";
 
   artifactHashes = {
-    linuxarm32 = "sha256-se2V9+d3HIiKIohbj8s7ilK1+kFH3kQvaaEP372h8b0=";
-    linuxarm64 = "sha256-gmYPmFafS2KETpxz4UWsX+h506dU4dkkatYT/OrQ5Zk=";
-    linuxx86-64 = "sha256-0dim48CQ7iYYuaNA4efKJOH1VDlgFoyeefDI2TxNMZ4=";
-    osxuniversal = "sha256-ZIgu4bdLBqQhtu4R1GGVV8BW9TWPV2o2F0//5F3kp7A=";
+    linuxarm32 = "sha256-3JMQ+XwA/5Our6FVybsObgPWaC0Dzo9E/Y2DKDnQefU=";
+    linuxarm64 = "sha256-fX3Jf0wHLCWZhgGoS7ZH03XMoUURQH6vl09E0cfhK1c=";
+    linuxx86-64 = "sha256-By5cgZqZV2EUkgJomRCbQnGQ7ZtBHglVYEn22vecY9Y=";
+    osxuniversal = "sha256-4+1AAZSL3yhmB/QmurybL/wej9QUsh83Xss3VD5k+Jw=";
   };
 
   iconPng = "${allwpilibSources}/datalogtool/src/main/native/resources/dlt-512.png";

--- a/pkgs/wpilib/default.nix
+++ b/pkgs/wpilib/default.nix
@@ -4,9 +4,9 @@ lib.makeScope pkgs.newScope (self: with self; {
   allwpilibSources = fetchFromGitHub rec {
     passthru = {
       branch = "release";
-      version = "2025.3.2";
-      java.version = "2025.3.2";
-      native.version = "2025.3.2";
+      version = "2026.1.1";
+      java.version = "2026.1.1";
+      native.version = "2026.1.1";
     };
 
     owner = "wpilibsuite";

--- a/pkgs/wpilib/glass.nix
+++ b/pkgs/wpilib/glass.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "Glass";
 
   artifactHashes = {
-    linuxarm32 = "sha256-WMb6j8nbmYthbnhsLwP3dBT4GWnGUqAgcqRmDml2Frg=";
-    linuxarm64 = "sha256-QmadCJMjMNfAR/OlV6JorP9LM+1kOdVGhZrci6HgCXM=";
-    linuxx86-64 = "sha256-UewMXfLsuf3s+CncC6ECMCX9JI0dY6EEa6W5z/p3xs4=";
-    osxuniversal = "sha256-QYbthmrCceR3hhDoM67SD5/NBGHymuMJf+dR9nGGWPg=";
+    linuxarm32 = "sha256-f4sV5RyvLrJZauRHXp3PSlqu0ii2qbNGe4ZEGPwpQH0=";
+    linuxarm64 = "sha256-BRQRzuUux57ZBC/d6qa2vqKn7CzH0KrUeN13Pk5pY6M=";
+    linuxx86-64 = "sha256-7bVDQQNl6R7cK1bpO+cFoQ3PJwaj5PZ9G2EQ0ouw2Ak=";
+    osxuniversal = "sha256-0qZc4rMbz69C1TUeWty0rxFHe/TSmso/xFYY9aupmm8=";
   };
 
   iconPng = "${allwpilibSources}/glass/src/app/native/resources/glass-512.png";

--- a/pkgs/wpilib/outlineviewer.nix
+++ b/pkgs/wpilib/outlineviewer.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "OutlineViewer";
 
   artifactHashes = {
-    linuxarm32 = "sha256-nEXmDIAB5ydhM58nyGONuXqSP33ZVTLGtxEjHl5QlK4=";
-    linuxarm64 = "sha256-Ik+H2vCJ2DMoX6qzjieXf1Z6toxVtBOmixTIZxDwIH4=";
-    linuxx86-64 = "sha256-GOUblM1GlrNusxRptndvdzjIoz9kwE9jNjvMcOc+AOM=";
-    osxuniversal = "sha256-FEE/8fa2ts5fTMhYR/GUI/cOHnnxSi/8P1WAFaYaeR4=";
+    linuxarm32 = "sha256-PX1rSGVxU22zBXp0a83GGeq83rLCWPw2evBITkJr1q8=";
+    linuxarm64 = "sha256-0YI8QV+Glq1BCdbjhuif4qG0im+0yIl8pOB2FXG9EuI=";
+    linuxx86-64 = "sha256-Deh3li6GSJ919l0iPAXh29B3D7bwgcQzKOkgl7hGnWo=";
+    osxuniversal = "sha256-Qa7G3q/wZ4QyM0U2A4HbEuWcH+q4XaNCDYaqPJ0DEhE=";
   };
 
   iconPng = "${allwpilibSources}/outlineviewer/src/main/native/resources/ov-512.png";

--- a/pkgs/wpilib/pathweaver.nix
+++ b/pkgs/wpilib/pathweaver.nix
@@ -6,11 +6,11 @@ buildJavaTool {
   name = "PathWeaver";
 
   artifactHashes = {
-    linuxarm32 = "sha256-KOOqcfq1eABxkiDQ7u1rCK578L+2w/s1a49H37XSWmU=";
-    linuxarm64 = "sha256-HMxFUuWaytxu2ZDdPmmnNADuwFHS/5MAGPat5I2iCV8=";
-    linuxx64 = "sha256-Rdz3wVxFpfcw+7Bp+RzT6Xnhw5dvRrzy+mYZrDFd+hY=";
-    macarm64 = "sha256-MjBjx9k473AIkzDbpBVh/a/pUuPbhN3eywQS3BYZoeU=";
-    macx64 = "sha256-AgnevTtWCEG+hTpmWe4PqDIsrhYri6B1lmFpdPas2VQ=";
+    linuxarm32 = "sha256-0Wq4+LRQhKf2hPRP55Ieu6TBnevZg/Islc+YIQ1bx6Q=";
+    linuxarm64 = "sha256-53KvfPIeeD5w2IRZCVXf5gKQRCTckRbvygsGSfqhb50=";
+    linuxx64 = "sha256-rkfpHRaN0lhLiAWCSZ7bv/LuUfqm5XzfbrgGW06oIWo=";
+    macarm64 = "sha256-/P9+xR2y4Fz1dT4p+GtTbocAmGTLl1XlJ4H9ZP9vNfU=";
+    macx64 = "sha256-3lerTp+TNPufZqM96KySQpF3eQ8MgPPzNTau669qr2U=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/roborioteamnumbersetter.nix
+++ b/pkgs/wpilib/roborioteamnumbersetter.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "roboRIOTeamNumberSetter";
 
   artifactHashes = {
-    linuxarm32 = "sha256-H56xH6iBLRLYWqOrPeR6uvomfDWNcHAPTN9wjhJqHBk=";
-    linuxarm64 = "sha256-70YpZPVLVWa+xpQWTX7nnV4e6gjdzcxHfpgOsw8py6c=";
-    linuxx86-64 = "sha256-bv5yyB3CgZHFjNO45u6CDc+TatyvX1tv4zcA89WQyGg=";
-    osxuniversal = "sha256-nIMT+MZ/RykxXZLngN/TgVSe+d6ukMrMP9L1iFXn1Bg=";
+    linuxarm32 = "sha256-DGzAA+bRxCBGKzNUTASzlN3JsCZ1fT/pyENkOHBY0vY=";
+    linuxarm64 = "sha256-UsIf2qwFthHwlMfTNPlkRe/jnRMsROOiwIv18n7S95c=";
+    linuxx86-64 = "sha256-asOGiPRuBEuNEYSEmPGAu0+DxfXkgRCfw/sa0chJF5U=";
+    osxuniversal = "sha256-r8Hul0nK0BLd3B6rflIdjZLskmzgy0T676IaCqD1oxk=";
   };
 
   extraLibs = [ avahi ];

--- a/pkgs/wpilib/robotbuilder.nix
+++ b/pkgs/wpilib/robotbuilder.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://frcmaven.wpi.edu/artifactory/${allwpilibSources.branch}/edu/wpi/first/tools/RobotBuilder/${version}/RobotBuilder-${version}.jar";
-    hash = "sha256-WrTrFMcNUArrnQLL2qXKzqhc8wn0Wm/8swCuYRcA5YU=";
+    hash = "sha256-ABzJVBITi7Aufcex29Ci6d9xX/oL2DQ4Pub4T1U1oBU=";
   };
 
   dontUnpack = true;

--- a/pkgs/wpilib/shuffleboard.nix
+++ b/pkgs/wpilib/shuffleboard.nix
@@ -6,11 +6,11 @@ buildJavaTool {
   name = "Shuffleboard";
 
   artifactHashes = {
-    linuxarm32 = "sha256-kICubqC0ks7s40D/vuf7bqXmHBmRNrmaioCwSHsMHhQ=";
-    linuxarm64 = "sha256-5370NBC2Lx5BXH6Y8WjmeRI+UfpKhu1mn0l6EJp8xhA=";
-    linuxx64 = "sha256-WO8jGCemjDHrRaw+zhfSM/p4uEEsNdqb+RLBmgFMdpg=";
-    macarm64 = "sha256-agsSEY74ApZA/lbaCBUWrDSqt/lbl1MocgFiGXZPcJw=";
-    macx64 = "sha256-s/I8M+6yUDMNvc0ZlatJP1yCeidsdM+GK0gjxCq8umw=";
+    linuxarm32 = "sha256-hK97mXb9w2lawmiN/G16FRctcsu+MK9UC5c2IHfXutg=";
+    linuxarm64 = "sha256-o8n/zPThkOqQ8LP9h5KZ4ko3PC754BE4RAJvcxylMXw=";
+    linuxx64 = "sha256-GU8cre1ACPqUEvDnz+zYckhmvdXstYWa7D9TgC+Sx58=";
+    macarm64 = "sha256-KhpAseWjoPEo5P3mOeWCgJfYR6ICldNLiIR1eJaNB+U=";
+    macx64 = "sha256-lfTmPAlzf/KSgCuIX4CzStQ+dlwtgJi9L0wpXEj+EiI=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/smartdashboard.nix
+++ b/pkgs/wpilib/smartdashboard.nix
@@ -6,8 +6,8 @@ buildJavaTool {
   name = "SmartDashboard";
 
   artifactHashes = {
-    linuxx64 = "sha256-waZ07PCT6LVCqEGNGTRldD6WHXzybDkTSsOAtj1qGGw=";
-    macx64 = "sha256-ImBQV/aUKTTgvDsybH4FgmrDYrCK7KQaHQiHAmbyIgw=";
+    linuxx64 = "sha256-NE4BdI3VyuEBeDbnJue2YSAmHPySCiPRWIRjmSj3Eew=";
+    macx64 = "sha256-12RwxsX4SJueqShoY5kQXjG+DIeZzerOJBxvJs7hWbw=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/sysid.nix
+++ b/pkgs/wpilib/sysid.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "SysId";
 
   artifactHashes = {
-    linuxarm32 = "sha256-AnLC8dVy85odvm/AQGaPuZs/Z2SnQwaj7uZcJHUS93Y=";
-    linuxarm64 = "sha256-f5Xq8GvimWzbcjiktaMGw79yYDpuEa0Ph6ikMZD/rJ4=";
-    linuxx86-64 = "sha256-iqhC5Hrmc4GMCjfvaMNa+gPOSr3Yf81siiMFB3SDHco=";
-    osxuniversal = "sha256-P0YI+UYYetJ38zVJxAH9DCCOsorpTxy/XFB6LOovbpg=";
+    linuxarm32 = "sha256-3i8F5/jkSSKF+utsW4L66hv8Q1MzmJLixRH5+0jkZD8=";
+    linuxarm64 = "sha256-Yvdp3roUat8rWqry9+TrwsKSeASdo1LLmuWedIXdOcQ=";
+    linuxx86-64 = "sha256-dVsZ5laDRXtmxKSE+gxpCYwl/4w0gjZO3qQicynufbM=";
+    osxuniversal = "sha256-/EffkQ74Hx5XObymMj/lOd/0cwx13cAeOEwUufi6j5s=";
   };
 
   iconPng = "${allwpilibSources}/sysid/src/main/native/resources/sysid-512.png";

--- a/pkgs/wpilib/vscode-extension.nix
+++ b/pkgs/wpilib/vscode-extension.nix
@@ -12,7 +12,7 @@ vscode-utils.buildVscodeExtension rec {
 
   src = fetchurl {
     url = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${version}/vscode-wpilib-${version}.vsix";
-    hash = "sha256-HAnN+1IYbma3v+sPyTivqDCIOdyClLz7FP/chlZ0SCI=";
+    hash = "sha256-+wzawFLCCY9L4957XROJQzOoURDwNhVQuQwgCCBPGxY=";
     # TODO: Once the version of nixpkgs in this flake is updated we should remove
     # the custom `name` and the `unzip` nativeBuildInput
     # See: https://github.com/NixOS/nixpkgs/commit/e24a734076ea21365bb618d63f5c9a70006dd196

--- a/pkgs/wpilib/wpical.nix
+++ b/pkgs/wpilib/wpical.nix
@@ -6,8 +6,10 @@ buildBinTool {
   name = "wpical";
 
   artifactHashes = {
-    linuxx86-64 = "sha256-UHxIcIhl2Ng4kWHcI2nQ6OeGsnTTzr9gLpJoiH+lzF4=";
-    osxuniversal = "sha256-6N7Qs/BQDnwJvPJKc3t+bA6wKDfnNDkvYGst1aqeoS4=";
+    linuxarm32 = "sha256-qcMMeNudAG5hvukoLDHOoqQchGA9UWzUjhhEfW1yvek=";
+    linuxarm64 = "sha256-s/EOBD758t7k3u0a5gX6PlFBq3MeqRrnlf3MCcdnHEY=";
+    linuxx86-64 = "sha256-MRUA7IetLhPSeIQgAtSpdZPc/fmyHyPmaSS8k7XB+K0=";
+    osxuniversal = "sha256-H60HyQ82WQ/EbSPh2YXtcWkzcH/Fvfs5peqBONgvg3c=";
   };
 
   extraLibs = [ gfortran.cc ];


### PR DESCRIPTION
## 🤖 Automated Package Updates

This PR updates the following packages to their latest available versions, and bumps nixpkgs to the latest unstable.

- **WPILib**: `2025.3.2` -> [`2026.1.1`](https://github.com/wpilibsuite/allwpilib/releases/tag/v2026.1.1)
  - Updated tools: glass, vscode-wpilib, outlineviewer, datalogtool, shuffleboard, smartdashboard, roborioteamnumbersetter, robotbuilder, sysid, wpical, pathweaver
- elastic-dashboard: `null` -> [`2026.0.0`](https://github.com/Gold872/elastic_dashboard/releases/tag/v2026.0.0)

### Review Notes
The checks have done a preliminary pass to make sure the packages build but functionality still needs to be tested manually.

  ---
🤖 Generated by [`frc-nix-update`](https://github.com/frc4451/frc-nix)