### PR TITLE
chore: update FRC packages and nixpkgs to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768127708,
-        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "lastModified": 1768305791,
+        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
         "type": "github"
       },
       "original": {

--- a/pkgs/elastic-dashboard/default.nix
+++ b/pkgs/elastic-dashboard/default.nix
@@ -9,11 +9,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "elastic-dashboard";
-  version = "2026.0.0";
+  version = "2026.1.0";
 
   src = fetchurl {
     url = "https://github.com/Gold872/elastic_dashboard/releases/download/v${version}/Elastic-Linux.zip";
-    hash = "sha256-Rfn5JbKaE89a+qdJX2yoPlKzuIWOPH5AlAttu7+JtxY=";
+    hash = "sha256-vhEv+REnkAUCbqFXY/GBtsvMazxz8I6IkKDAjxet/GM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/wpilib/datalogtool.nix
+++ b/pkgs/wpilib/datalogtool.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "DataLogTool";
 
   artifactHashes = {
-    linuxarm32 = "sha256-3JMQ+XwA/5Our6FVybsObgPWaC0Dzo9E/Y2DKDnQefU=";
-    linuxarm64 = "sha256-fX3Jf0wHLCWZhgGoS7ZH03XMoUURQH6vl09E0cfhK1c=";
-    linuxx86-64 = "sha256-By5cgZqZV2EUkgJomRCbQnGQ7ZtBHglVYEn22vecY9Y=";
-    osxuniversal = "sha256-4+1AAZSL3yhmB/QmurybL/wej9QUsh83Xss3VD5k+Jw=";
+    linuxarm32 = "sha256-MULfrpcqUj46C1onKvYufDdeBz54cdOrn+7I57ZUBL0=";
+    linuxarm64 = "sha256-oKucdCHQhrCS9StWQq3kfCVNram5hZqc/iSGWOcgGyw=";
+    linuxx86-64 = "sha256-gIUE4wO6xES9s3i/mxoIswurwtGrC7X5yk5Dv5x0hLQ=";
+    osxuniversal = "sha256-Mi4YiWe8PEOniM67j99IeuwifUNGf4tTFZOwvxYuY1c=";
   };
 
   iconPng = "${allwpilibSources}/datalogtool/src/main/native/resources/dlt-512.png";

--- a/pkgs/wpilib/default.nix
+++ b/pkgs/wpilib/default.nix
@@ -4,15 +4,15 @@ lib.makeScope pkgs.newScope (self: with self; {
   allwpilibSources = fetchFromGitHub rec {
     passthru = {
       branch = "release";
-      version = "2026.1.1";
-      java.version = "2026.1.1";
-      native.version = "2026.1.1";
+      version = "2026.2.1";
+      java.version = "2026.2.1";
+      native.version = "2026.2.1";
     };
 
     owner = "wpilibsuite";
     repo = "allwpilib";
     rev = "v${passthru.version}";
-    hash = "sha256-deBeDguJckUxh+1E8dSzR1xKa/f+Q4qU2AOG2F9sKAU=";
+    hash = "sha256-JKhd8s10sgWtV3cMYP9hVlbydvulyaFtRjn19gnFAfE=";
   };
 
   buildBinTool = callPackage ./build-bin-tool.nix { };

--- a/pkgs/wpilib/glass.nix
+++ b/pkgs/wpilib/glass.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "Glass";
 
   artifactHashes = {
-    linuxarm32 = "sha256-f4sV5RyvLrJZauRHXp3PSlqu0ii2qbNGe4ZEGPwpQH0=";
-    linuxarm64 = "sha256-BRQRzuUux57ZBC/d6qa2vqKn7CzH0KrUeN13Pk5pY6M=";
-    linuxx86-64 = "sha256-7bVDQQNl6R7cK1bpO+cFoQ3PJwaj5PZ9G2EQ0ouw2Ak=";
-    osxuniversal = "sha256-0qZc4rMbz69C1TUeWty0rxFHe/TSmso/xFYY9aupmm8=";
+    linuxarm32 = "sha256-dw39MUpbDENfnzgWI54NRZcb2IO0kqscA7XBBZYQk84=";
+    linuxarm64 = "sha256-QWkMugXCHPQqu3Wb7a1ex/h6BDbBR8z1Sgkfpj+TUd4=";
+    linuxx86-64 = "sha256-S+kKWZWRBzVhTp0GSLBW1qC8QUDrsIBxxGxlLvmcALQ=";
+    osxuniversal = "sha256-KoYyGDCNjCP07LT/SVMtFnObIfJPIYyuLZQS+9gW3V4=";
   };
 
   iconPng = "${allwpilibSources}/glass/src/app/native/resources/glass-512.png";

--- a/pkgs/wpilib/outlineviewer.nix
+++ b/pkgs/wpilib/outlineviewer.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "OutlineViewer";
 
   artifactHashes = {
-    linuxarm32 = "sha256-PX1rSGVxU22zBXp0a83GGeq83rLCWPw2evBITkJr1q8=";
-    linuxarm64 = "sha256-0YI8QV+Glq1BCdbjhuif4qG0im+0yIl8pOB2FXG9EuI=";
-    linuxx86-64 = "sha256-Deh3li6GSJ919l0iPAXh29B3D7bwgcQzKOkgl7hGnWo=";
-    osxuniversal = "sha256-Qa7G3q/wZ4QyM0U2A4HbEuWcH+q4XaNCDYaqPJ0DEhE=";
+    linuxarm32 = "sha256-mUO2wCjuYae4/cY3voRqgLpLVHq14BoDCIFYfAUHdU4=";
+    linuxarm64 = "sha256-8Wcz/9Nj5M/384fyOKkTAFyiOeILc4chsRSS0docidk=";
+    linuxx86-64 = "sha256-3+fanb9EJMOu4wX35H+rvkNGe8+KG6B9/YyUhexNfY0=";
+    osxuniversal = "sha256-e5l18l/m/4eYjJC6Sf5lBwbtVaSDi2RaWGSAmMMsuT4=";
   };
 
   iconPng = "${allwpilibSources}/outlineviewer/src/main/native/resources/ov-512.png";

--- a/pkgs/wpilib/pathweaver.nix
+++ b/pkgs/wpilib/pathweaver.nix
@@ -6,11 +6,11 @@ buildJavaTool {
   name = "PathWeaver";
 
   artifactHashes = {
-    linuxarm32 = "sha256-0Wq4+LRQhKf2hPRP55Ieu6TBnevZg/Islc+YIQ1bx6Q=";
-    linuxarm64 = "sha256-53KvfPIeeD5w2IRZCVXf5gKQRCTckRbvygsGSfqhb50=";
-    linuxx64 = "sha256-rkfpHRaN0lhLiAWCSZ7bv/LuUfqm5XzfbrgGW06oIWo=";
-    macarm64 = "sha256-/P9+xR2y4Fz1dT4p+GtTbocAmGTLl1XlJ4H9ZP9vNfU=";
-    macx64 = "sha256-3lerTp+TNPufZqM96KySQpF3eQ8MgPPzNTau669qr2U=";
+    linuxarm32 = "sha256-/urmq7VA2WT875Edjgo2Iopf/P2aAzv1YD16JO8GILY=";
+    linuxarm64 = "sha256-DnTc7bGRmJ0kdq504SvG5tz+i0V/55+QKGpdTLTNouY=";
+    linuxx64 = "sha256-bHb2me2AnpQYVSwLU3gMeOFtKz2Zu4Hc4KxQQsckrqA=";
+    macarm64 = "sha256-y6nLIsPlflO2k8h/J8bRzXxPCN/cyP5PYpuAF3KQqQA=";
+    macx64 = "sha256-wV7V33cHLKkzAJlnionwjLZHSY29Kh3GoTBkthYyjvk=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/roborioteamnumbersetter.nix
+++ b/pkgs/wpilib/roborioteamnumbersetter.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "roboRIOTeamNumberSetter";
 
   artifactHashes = {
-    linuxarm32 = "sha256-DGzAA+bRxCBGKzNUTASzlN3JsCZ1fT/pyENkOHBY0vY=";
-    linuxarm64 = "sha256-UsIf2qwFthHwlMfTNPlkRe/jnRMsROOiwIv18n7S95c=";
-    linuxx86-64 = "sha256-asOGiPRuBEuNEYSEmPGAu0+DxfXkgRCfw/sa0chJF5U=";
-    osxuniversal = "sha256-r8Hul0nK0BLd3B6rflIdjZLskmzgy0T676IaCqD1oxk=";
+    linuxarm32 = "sha256-/i2t0bUJFiA5gIEc3Xk1Mh0JM34R6Oo2vk/o2vTgxtg=";
+    linuxarm64 = "sha256-EGfcYnLvJUpJMfkHBZSfKPCMtrI7nVNGrs0UDwWqLCU=";
+    linuxx86-64 = "sha256-eLTkHADQZapX0Yl4YSFd7Zepd0Uiu8/QBMyMaYYd5Ms=";
+    osxuniversal = "sha256-zmkjmq0ngPMKmGX1BRKbwzsi2c/UA1vCAk3brXuj8WQ=";
   };
 
   extraLibs = [ avahi ];

--- a/pkgs/wpilib/robotbuilder.nix
+++ b/pkgs/wpilib/robotbuilder.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://frcmaven.wpi.edu/artifactory/${allwpilibSources.branch}/edu/wpi/first/tools/RobotBuilder/${version}/RobotBuilder-${version}.jar";
-    hash = "sha256-ABzJVBITi7Aufcex29Ci6d9xX/oL2DQ4Pub4T1U1oBU=";
+    hash = "sha256-+UWUp2zPJIvjFFMfHkaWX9a8gkzs4JvmD1VhVZoKYD8=";
   };
 
   dontUnpack = true;

--- a/pkgs/wpilib/shuffleboard.nix
+++ b/pkgs/wpilib/shuffleboard.nix
@@ -6,11 +6,11 @@ buildJavaTool {
   name = "Shuffleboard";
 
   artifactHashes = {
-    linuxarm32 = "sha256-hK97mXb9w2lawmiN/G16FRctcsu+MK9UC5c2IHfXutg=";
-    linuxarm64 = "sha256-o8n/zPThkOqQ8LP9h5KZ4ko3PC754BE4RAJvcxylMXw=";
-    linuxx64 = "sha256-GU8cre1ACPqUEvDnz+zYckhmvdXstYWa7D9TgC+Sx58=";
-    macarm64 = "sha256-KhpAseWjoPEo5P3mOeWCgJfYR6ICldNLiIR1eJaNB+U=";
-    macx64 = "sha256-lfTmPAlzf/KSgCuIX4CzStQ+dlwtgJi9L0wpXEj+EiI=";
+    linuxarm32 = "sha256-NkWwRcn9n8OYAdq8nyDl7KYZsFe3ICb69rwdqkIRNdw=";
+    linuxarm64 = "sha256-rkceuqMLo+m9pQJ8352pNEP6JNwFyQ2dE3Qo0QQIWqQ=";
+    linuxx64 = "sha256-gQr6UoO1C5MLV3dSms0dRRAE0gfBi7pyz8h6RN0z/dA=";
+    macarm64 = "sha256-tkRnWQxWKg4ZUXlykS2VeXfPDGnJIOlM4FNjKYiUUCY=";
+    macx64 = "sha256-z97XKZMoEOwa4OPzrRP3VOOeyTETtGrR8HAVKYyr/PE=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/smartdashboard.nix
+++ b/pkgs/wpilib/smartdashboard.nix
@@ -6,8 +6,8 @@ buildJavaTool {
   name = "SmartDashboard";
 
   artifactHashes = {
-    linuxx64 = "sha256-NE4BdI3VyuEBeDbnJue2YSAmHPySCiPRWIRjmSj3Eew=";
-    macx64 = "sha256-12RwxsX4SJueqShoY5kQXjG+DIeZzerOJBxvJs7hWbw=";
+    linuxx64 = "sha256-V6iIAJtkuZVYK9wDgKD5FRoCK2ROYbsoArobPAKlzXs=";
+    macx64 = "sha256-Oaam2d9X0kZxHR/oVDJG63kku8NfIBNwYFvau70O86I=";
   };
 
   iconSvg = ./wpilib_logo.svg;

--- a/pkgs/wpilib/sysid.nix
+++ b/pkgs/wpilib/sysid.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "SysId";
 
   artifactHashes = {
-    linuxarm32 = "sha256-3i8F5/jkSSKF+utsW4L66hv8Q1MzmJLixRH5+0jkZD8=";
-    linuxarm64 = "sha256-Yvdp3roUat8rWqry9+TrwsKSeASdo1LLmuWedIXdOcQ=";
-    linuxx86-64 = "sha256-dVsZ5laDRXtmxKSE+gxpCYwl/4w0gjZO3qQicynufbM=";
-    osxuniversal = "sha256-/EffkQ74Hx5XObymMj/lOd/0cwx13cAeOEwUufi6j5s=";
+    linuxarm32 = "sha256-L/VETxQTybZTlVExGj6ytmCjFdqtbZQzAadxiIJgL2Q=";
+    linuxarm64 = "sha256-2gA2aq1iGyk0xhIGp2+UqHg8iUfKVOgqzQsgm4Kwe3o=";
+    linuxx86-64 = "sha256-w570+kJGLZSGzCACRSqArGDNXthkMhL6h3ZbL1rtTjs=";
+    osxuniversal = "sha256-FRgbe2M7pzqz3gbW63RKOyQY77oNOL0HVgXUAsY7VPI=";
   };
 
   iconPng = "${allwpilibSources}/sysid/src/main/native/resources/sysid-512.png";

--- a/pkgs/wpilib/wpical.nix
+++ b/pkgs/wpilib/wpical.nix
@@ -6,10 +6,10 @@ buildBinTool {
   name = "wpical";
 
   artifactHashes = {
-    linuxarm32 = "sha256-qcMMeNudAG5hvukoLDHOoqQchGA9UWzUjhhEfW1yvek=";
-    linuxarm64 = "sha256-s/EOBD758t7k3u0a5gX6PlFBq3MeqRrnlf3MCcdnHEY=";
-    linuxx86-64 = "sha256-MRUA7IetLhPSeIQgAtSpdZPc/fmyHyPmaSS8k7XB+K0=";
-    osxuniversal = "sha256-H60HyQ82WQ/EbSPh2YXtcWkzcH/Fvfs5peqBONgvg3c=";
+    linuxarm32 = "sha256-mfoCIrGm8Mx32cpnARpOMZ/BkIR1F2es87iXQKNlOos=";
+    linuxarm64 = "sha256-UywqegrJyj8WhtjD4WxGpRmS29Ik5bGPf08AMXwQAew=";
+    linuxx86-64 = "sha256-vhkLWbS/Lz0igAjt25Gj6GTbbmDcdHwDwmVMsfOneZk=";
+    osxuniversal = "sha256-zCZr/GnEHlplgI+6RcQ+owt2LKTPJNieNW68hfwIgvw=";
   };
 
   extraLibs = [ gfortran.cc ];


### PR DESCRIPTION
## 🤖 Automated Package Updates

This PR updates the following packages to their latest available versions, and bumps nixpkgs to the latest unstable.

- **WPILib**: `2026.1.1` -> [`2026.2.1`](https://github.com/wpilibsuite/allwpilib/releases/tag/v2026.2.1)
  - Updated tools: glass, outlineviewer, datalogtool, shuffleboard, smartdashboard, roborioteamnumbersetter, robotbuilder, sysid, wpical, pathweaver
- elastic-dashboard: `2026.0.0` -> [`2026.1.0`](https://github.com/Gold872/elastic_dashboard/releases/tag/v2026.1.0)

### Review Notes
The checks have done a preliminary pass to make sure the packages build but functionality still needs to be tested manually.

  ---
🤖 Generated by [`frc-nix-update`](https://github.com/frc4451/frc-nix)