### PR TITLE
chore: update FRC packages and nixpkgs to latest versions

### DIFF
--- a/pkgs/elastic-dashboard/default.nix
+++ b/pkgs/elastic-dashboard/default.nix
@@ -9,11 +9,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "elastic-dashboard";
-  version = "2026.1.0";
+  version = "2026.1.1";
 
   src = fetchurl {
     url = "https://github.com/Gold872/elastic_dashboard/releases/download/v${version}/Elastic-Linux.zip";
-    hash = "sha256-vhEv+REnkAUCbqFXY/GBtsvMazxz8I6IkKDAjxet/GM=";
+    hash = "sha256-X+tUymyIo8OTGqUBBHZLa0OKLiCIRYaqz/E6tNwWEMg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## 🤖 Automated Package Updates

This PR updates the following packages to their latest available versions, and bumps nixpkgs to the latest unstable.

- elastic-dashboard: `2026.1.0` -> [`2026.1.1`](https://github.com/Gold872/elastic_dashboard/releases/tag/v2026.1.1)

### Review Notes
The checks have done a preliminary pass to make sure the packages build but functionality still needs to be tested manually.

  ---
🤖 Generated by [`frc-nix-update`](https://github.com/frc4451/frc-nix)