### PR TITLE
chore: update FRC packages and nixpkgs to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768305791,
-        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
         "type": "github"
       },
       "original": {

--- a/pkgs/wpilib/vscode-extension.nix
+++ b/pkgs/wpilib/vscode-extension.nix
@@ -5,14 +5,14 @@
 , lib
 }:
 vscode-utils.buildVscodeExtension rec {
-  version = "2026.1.1";
+  version = "2026.2.1";
 
   pname = "${vscodeExtPublisher}-${vscodeExtName}";
   name = "${vscodeExtPublisher}-${vscodeExtName}-${version}";
 
   src = fetchurl {
     url = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${version}/vscode-wpilib-${version}.vsix";
-    hash = "sha256-+wzawFLCCY9L4957XROJQzOoURDwNhVQuQwgCCBPGxY=";
+    hash = "sha256-Qj9CHQk8ODZiILGEbhBdBl5wLpAf9RsYa7avYT4ns7Y=";
     # TODO: Once the version of nixpkgs in this flake is updated we should remove
     # the custom `name` and the `unzip` nativeBuildInput
     # See: https://github.com/NixOS/nixpkgs/commit/e24a734076ea21365bb618d63f5c9a70006dd196


### PR DESCRIPTION
## 🤖 Automated Package Updates

This PR updates the following packages to their latest available versions, and bumps nixpkgs to the latest unstable.



### Review Notes
The checks have done a preliminary pass to make sure the packages build but functionality still needs to be tested manually.

  ---
🤖 Generated by [`frc-nix-update`](https://github.com/frc4451/frc-nix)