### PR TITLE
Remove references to xorg package set

### DIFF
--- a/pkgs/wpilib/buildBinTool.nix
+++ b/pkgs/wpilib/buildBinTool.nix
@@ -9,7 +9,7 @@
   makeDesktopItem,
   makeWrapper,
   libGL,
-  xorg,
+  libx11,
   zenity,
 }:
 lib.extendMkDerivation {
@@ -69,7 +69,7 @@ lib.extendMkDerivation {
       libraries = [
         stdenv.cc.cc
         libGL
-        xorg.libX11
+        libx11
       ]
       ++ extraLibs;
 

--- a/pkgs/wpilib/buildJavaTool.nix
+++ b/pkgs/wpilib/buildJavaTool.nix
@@ -6,7 +6,8 @@
   makeWrapper,
   temurin-jre-bin-17,
   libGL,
-  xorg,
+  libx11,
+  libxtst,
   gtk2,
   copyDesktopItems,
   makeDesktopItem,
@@ -72,8 +73,8 @@ lib.extendMkDerivation {
         [
           stdenv.cc.cc
           libGL
-          xorg.libX11
-          xorg.libXtst
+          libx11
+          libxtst
           gtk2
         ]
         ++ extraLibs


### PR DESCRIPTION
Removed all references to the xorg package set, as it has been deprecated. See: https://github.com/NixOS/nixpkgs/issues/479553.

This change is compatible with the version of nixpkgs present in this repo.