### PR TITLE
chore: update FRC packages and nixpkgs to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1772198003,
+        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
         "type": "github"
       },
       "original": {

--- a/pkgs/choreo/package.nix
+++ b/pkgs/choreo/package.nix
@@ -11,11 +11,11 @@
 }:
 let
   pname = "choreo";
-  version = "2026.0.1";
+  version = "2026.0.2";
 
   src = fetchurl {
     url = "https://github.com/SleipnirGroup/Choreo/releases/download/v${version}/Choreo-v${version}-Linux-x86_64-standalone.zip";
-    hash = "sha256-scFL0lo9rhVZBPpqLeLoWcGPiXhDMvrDQEjp6TlwsKg=";
+    hash = "sha256-nXgAhu2r3TC5T8U/XqdtSVMr4XCF4hWNlH/L9bLJ6Dk=";
   };
 
   icon = fetchurl {

--- a/pkgs/elastic-dashboard/package.nix
+++ b/pkgs/elastic-dashboard/package.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "elastic-dashboard";
-  version = "2026.1.1";
+  version = "2026.1.2";
 
   src = fetchurl {
     url = "https://github.com/Gold872/elastic_dashboard/releases/download/v${version}/Elastic-Linux.zip";
-    hash = "sha256-X+tUymyIo8OTGqUBBHZLa0OKLiCIRYaqz/E6tNwWEMg=";
+    hash = "sha256-YQO3D+F4jO5JKZFvj4uZh+/jz0aarxIvR87PuD9iZ8E=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## 🤖 Automated Package Updates

This PR updates the following packages to their latest available versions, and bumps nixpkgs to the latest unstable.

- elastic-dashboard: `2026.1.1` -> [`2026.1.2`](https://github.com/Gold872/elastic_dashboard/releases/tag/v2026.1.2)
- choreo: `2026.0.1` -> [`2026.0.2`](https://github.com/SleipnirGroup/Choreo/releases/tag/v2026.0.2)

### Review Notes
The checks have done a preliminary pass to make sure the packages build but functionality still needs to be tested manually.

  ---
🤖 Generated by [`frc-nix-update`](https://github.com/frc4451/frc-nix)