### PR TITLE
rev-hardware-client-2: init

### DIFF
--- a/pkgs/rev-hardware-client-2/package.nix
+++ b/pkgs/rev-hardware-client-2/package.nix
@@ -1,111 +1,133 @@
 {
   lib,
+  buildFHSEnv,
   stdenv,
-  autoPatchelfHook,
   fetchurl,
 
-  wrapGAppsHook4,
-
+  alsa-lib,
   at-spi2-atk,
+  at-spi2-core,
+  atk,
+  autoPatchelfHook,
   cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
   glib,
   gtk3,
-  pango,
-  libx11,
-
-  cups,
-  libxrandr,
-  libxdamage,
-  libxcursor,
-  libxtst,
-  libgcc,
+  libGL,
   libdrm,
   libgbm,
-  nss,
-  libxxf86vm,
-
-  nspr,
-  atk,
-  expat,
-  libxkbcommon,
-  alsa-lib,
-  dbus,
-  at-spi2-core,
-  libGL,
-  udev,
-  systemdLibs,
-  libxfixes,
-  libxext,
-  libxcomposite,
-  libxshmfence,
+  libgcc,
+  libx11,
   libxcb,
-
-  fontconfig,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxkbcommon,
+  libxrandr,
+  libxshmfence,
+  libxtst,
+  libxxf86vm,
+  nspr,
+  nss,
+  pango,
+  systemdLibs,
+  udev,
+  wrapGAppsHook3,
 }:
-stdenv.mkDerivation (finalAttrs: {
+let
   pname = "rev-hardware-client-2";
   version = "1.0.7";
 
-  src = fetchurl {
-    url = "https://rhc2.revrobotics.com/download/rev-hardware-client-1.0.7-linux-amd64.tar.gz";
-    hash = "sha256-dIn32bBVarRVoHSG0cZiIt5W33Q5YuQToaZvN/Q8p7s=";
-  };
+  rhc2-unwrapped = stdenv.mkDerivation (finalAttrs: {
+    pname = "${pname}-unwrapped";
+    inherit version;
+    src = fetchurl {
+      url = "https://rhc2.revrobotics.com/download/rev-hardware-client-1.0.7-linux-amd64.tar.gz";
+      hash = "sha256-dIn32bBVarRVoHSG0cZiIt5W33Q5YuQToaZvN/Q8p7s=";
+    };
 
-  nativeBuildInputs = [
-    # wrapGAppsHook3
-    wrapGAppsHook4
-    autoPatchelfHook
-  ];
+    nativeBuildInputs = [
+      autoPatchelfHook
+      wrapGAppsHook3
+    ];
 
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cairo
-    cups
-    cups.lib
-    dbus
-    expat
-    glib
-    gtk3
-    libGL
-    libdrm
-    libgbm
-    libgcc
-    libx11
-    libxcb
-    libxcomposite
-    libxcursor
-    libxdamage
-    libxext
-    libxfixes
-    libxkbcommon
-    libxrandr
-    libxshmfence
-    libxtst
-    libxxf86vm
-    nspr
-    nss
-    pango
-    stdenv.cc.cc
-    systemdLibs
-    udev
+    buildInputs = [
+      alsa-lib
+      at-spi2-atk
+      at-spi2-core
+      atk
+      cairo
+      cairo
+      cups
+      cups.lib
+      dbus
+      expat
+      glib
+      gtk3
+      libdrm
+      libgbm
+      libgcc
+      libx11
+      libxcb
+      libxcomposite
+      libxcursor
+      libxdamage
+      libxext
+      libxfixes
+      libxkbcommon
+      libxrandr
+      libxshmfence
+      libxtst
+      libxxf86vm
+      nspr
+      nss
+      pango
+      systemdLibs
+      udev
+    ];
+
+    runtimeDependencies = [
+      fontconfig
+      libGL
+      udev
+      stdenv.cc.cc
+    ];
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r . $out/
+      substituteInPlace $out/share/applications/com.revrobotics.revui.rev-hardware-client.desktop \
+      --replace-fail Exec=/usr/lib/rev-robotics/rev-hardware-client/bin/rev-hardware-client Exec=rev-hardware-client
+
+      runHook postInstall
+    '';
+  });
+in
+buildFHSEnv {
+  inherit pname version;
+
+  targetPkgs = _: [
+    rhc2-unwrapped
+
     fontconfig
+    libGL
+    udev
   ];
 
-  dontBuild = true;
+  runScript = "rev-hardware-client";
 
-  installPhase = ''
-    runHook preInstall
-
-    cp -r . $out/
-
-    runHook postInstall
+  extraInstallCommands = ''
+    mkdir -p $out/
+    cp -r ${rhc2-unwrapped}/share $out/share
   '';
-
-  # preFixup = "";
 
   meta = {
     description = "Hardware client for REV devices.";
@@ -115,4 +137,4 @@ stdenv.mkDerivation (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = [ "x86_64-linux" ];
   };
-})
+}

--- a/pkgs/rev-hardware-client-2/package.nix
+++ b/pkgs/rev-hardware-client-2/package.nix
@@ -1,29 +1,118 @@
 {
   lib,
-  stdenvNoCC,
-  makeWrapper,
+  stdenv,
+  autoPatchelfHook,
+  fetchurl,
+
+  wrapGAppsHook4,
+
+  at-spi2-atk,
+  cairo,
+  glib,
+  gtk3,
+  pango,
+  libx11,
+
+  cups,
+  libxrandr,
+  libxdamage,
+  libxcursor,
+  libxtst,
+  libgcc,
+  libdrm,
+  libgbm,
+  nss,
+  libxxf86vm,
+
+  nspr,
+  atk,
+  expat,
+  libxkbcommon,
+  alsa-lib,
+  dbus,
+  at-spi2-core,
+  libGL,
+  udev,
+  systemdLibs,
+  libxfixes,
+  libxext,
+  libxcomposite,
+  libxshmfence,
+  libxcb,
+
+  fontconfig,
 }:
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rev-hardware-client-2";
   version = "1.0.7";
 
-  src = fetchTarball {
+  src = fetchurl {
     url = "https://rhc2.revrobotics.com/download/rev-hardware-client-1.0.7-linux-amd64.tar.gz";
-
+    hash = "sha256-dIn32bBVarRVoHSG0cZiIt5W33Q5YuQToaZvN/Q8p7s=";
   };
 
   nativeBuildInputs = [
-    makeWrapper
+    # wrapGAppsHook3
+    wrapGAppsHook4
+    autoPatchelfHook
   ];
 
-  # buildInputs = [
-  #
-  # ];
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cairo
+    cups
+    cups.lib
+    dbus
+    expat
+    glib
+    gtk3
+    libGL
+    libdrm
+    libgbm
+    libgcc
+    libx11
+    libxcb
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxkbcommon
+    libxrandr
+    libxshmfence
+    libxtst
+    libxxf86vm
+    nspr
+    nss
+    pango
+    stdenv.cc.cc
+    systemdLibs
+    udev
+    fontconfig
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r . $out/
+
+    runHook postInstall
+  '';
+
+  # preFixup = "";
 
   meta = {
     description = "Hardware client for REV devices.";
-    homepage = "";
-    license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ ];
+    homepage = "https://docs.revrobotics.com/rev-hardware-client-2";
+    # license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ nullcube ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/rev-hardware-client-2/package.nix
+++ b/pkgs/rev-hardware-client-2/package.nix
@@ -8,7 +8,6 @@
   at-spi2-atk,
   at-spi2-core,
   atk,
-  autoPatchelfHook,
   cairo,
   cups,
   dbus,
@@ -27,8 +26,10 @@
   libxdamage,
   libxext,
   libxfixes,
+  libxi,
   libxkbcommon,
   libxrandr,
+  libxrender,
   libxshmfence,
   libxtst,
   libxxf86vm,
@@ -37,7 +38,6 @@
   pango,
   systemdLibs,
   udev,
-  wrapGAppsHook3,
 }:
 let
   pname = "rev-hardware-client-2";
@@ -50,53 +50,6 @@ let
       url = "https://rhc2.revrobotics.com/download/rev-hardware-client-1.0.7-linux-amd64.tar.gz";
       hash = "sha256-dIn32bBVarRVoHSG0cZiIt5W33Q5YuQToaZvN/Q8p7s=";
     };
-
-    nativeBuildInputs = [
-      autoPatchelfHook
-      wrapGAppsHook3
-    ];
-
-    buildInputs = [
-      alsa-lib
-      at-spi2-atk
-      at-spi2-core
-      atk
-      cairo
-      cairo
-      cups
-      cups.lib
-      dbus
-      expat
-      glib
-      gtk3
-      libdrm
-      libgbm
-      libgcc
-      libx11
-      libxcb
-      libxcomposite
-      libxcursor
-      libxdamage
-      libxext
-      libxfixes
-      libxkbcommon
-      libxrandr
-      libxshmfence
-      libxtst
-      libxxf86vm
-      nspr
-      nss
-      pango
-      systemdLibs
-      udev
-    ];
-
-    runtimeDependencies = [
-      fontconfig
-      libGL
-      udev
-      stdenv.cc.cc
-    ];
 
     dontBuild = true;
 
@@ -117,8 +70,41 @@ buildFHSEnv {
   targetPkgs = _: [
     rhc2-unwrapped
 
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    # cups.lib
+    dbus
+    expat
     fontconfig
+    glib
+    gtk3
     libGL
+    libdrm
+    libgbm
+    libgcc
+    libx11
+    libxcb
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxkbcommon
+    libxrandr
+    libxrender
+    libxshmfence
+    libxtst
+    libxxf86vm
+    nspr
+    nss
+    pango
+    stdenv.cc.cc
+    systemdLibs
     udev
   ];
 

--- a/pkgs/rev-hardware-client-2/package.nix
+++ b/pkgs/rev-hardware-client-2/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rev-hardware-client-2";
+  version = "1.0.7";
+
+  src = fetchTarball {
+    url = "https://rhc2.revrobotics.com/download/rev-hardware-client-1.0.7-linux-amd64.tar.gz";
+
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  # buildInputs = [
+  #
+  # ];
+
+  meta = {
+    description = "Hardware client for REV devices.";
+    homepage = "";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ];
+  };
+})


### PR DESCRIPTION
Fixes: #66 

Opened as a draft as I have only gotten it mostly working a FHSEnv, and it has a few issues:

- It requires BuildFHSEnv, otherwise it complains about `java.lang.RuntimeException: Fontconfig head is null, check your fonts or fonts configuration`, not necessarily an issue but I suspect it might be causing other issues?
- It spawns a empty black window in addition to the main client window
- It has an error about DBus? `Failed to call method: org.freedesktop.DBus.Properties.GetAll` or something.
- In the telemetry tab when you click the Load or Save Layout button the following appears in the terminal and nothing happens:
```console
[76012:76124:0323/205514.391703:ERROR:cef/libcef/browser/file_dialog_manager.cc:407] Default dialog implementation is not available; canceling the file dialog
```

Other Notes:

The program uses [Java CEF](https://github.com/chromiumembedded/java-cef), (aka JCEF) which makes it a smidge annoying to package. I've been trying to reference other nixpkgs packages for how best to package this and the closest I've come across so far is [bolt-launcher](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/bo/bolt-launcher/package.nix), and the regular [cef-binary](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ce/cef-binary/package.nix), but also I haven't looked super closely. I haven't looked that far into trying to patch JCEF yet, again I suspect that is causing a couple issues. But it does work inside of the FHSEnv, mostly lol!

The [download page](https://rhc2.revrobotics.com/download/download.html) seems to imply that there are other architecture options besides x86_64 (with the whole `dpkg --print-architecture` and all) but as far as I can tell there only exists a x86_64 build for linux?

I also don't have anything to properly test this with at the moment and my team isn't meeting for a couple weeks.

All the commit names are temporary due to this being a draft, I intend to squash/rebase once I have a fully working version with minimal issues.