### PR TITLE
chore: update FRC packages and nixpkgs to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {

--- a/pkgs/choreo/package.nix
+++ b/pkgs/choreo/package.nix
@@ -11,11 +11,11 @@
 }:
 let
   pname = "choreo";
-  version = "2026.0.2";
+  version = "2026.0.3";
 
   src = fetchurl {
     url = "https://github.com/SleipnirGroup/Choreo/releases/download/v${version}/Choreo-v${version}-Linux-x86_64-standalone.zip";
-    hash = "sha256-nXgAhu2r3TC5T8U/XqdtSVMr4XCF4hWNlH/L9bLJ6Dk=";
+    hash = "sha256-5w1CHQZ+0/rq6uStU3q36C6rzpg1TmlIILYSGQqx3ks=";
   };
 
   icon = fetchurl {


### PR DESCRIPTION
## 🤖 Automated Package Updates

This PR updates the following packages to their latest available versions, and bumps nixpkgs to the latest unstable.

- choreo: `2026.0.2` -> [`2026.0.3`](https://github.com/SleipnirGroup/Choreo/releases/tag/v2026.0.3)

### Review Notes
The checks have done a preliminary pass to make sure the packages build but functionality still needs to be tested manually.

  ---
🤖 Generated by [`frc-nix-update`](https://github.com/frc4451/frc-nix)