### PR TITLE
chore: update FRC packages and nixpkgs to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {

--- a/pkgs/advantagescope/package.nix
+++ b/pkgs/advantagescope/package.nix
@@ -39,13 +39,13 @@
 }:
 let
   pname = "advantagescope";
-  version = "26.0.1";
+  version = "26.0.2";
 
   src = fetchFromGitHub {
     owner = "Mechanical-Advantage";
     repo = "AdvantageScope";
     tag = "v${version}";
-    hash = "sha256-KL3SAr8SxY6e4EKP6dnEUHiZmvY3l/OD2pQIwrfzDSI=";
+    hash = "sha256-w12dxJyR+HmCKb1TE+W5qfd1Uyf+wam0AGachv7UbjI=";
   };
 
   patches = [
@@ -68,7 +68,7 @@ let
   docs = callPackage ./docs.nix fetchersAtters;
   licenses = callPackage ./licenses.nix fetchersAtters;
   tesseract = callPackage ./tesseract-lang.nix fetchersAtters;
-  npmDepsHash = "sha256-ccBDQm002bKCmMf6WCrFU+24UQM/FkNhkHtcI0BmRwk=";
+  npmDepsHash = "sha256-+ounOAUnYv8RqYPS6VxZHSmIRXGJ6D+iFcr/0MKGu0c=";
 
   system = stdenv.hostPlatform.system;
 


### PR DESCRIPTION
## 🤖 Automated Package Updates

This PR updates the following packages to their latest available versions, and bumps nixpkgs to the latest unstable.

- advantagescope: `26.0.1` -> [`26.0.2`](https://github.com/Mechanical-Advantage/AdvantageScope/releases/tag/v26.0.2)

### Review Notes
The checks have done a preliminary pass to make sure the packages build but functionality still needs to be tested manually.

  ---
🤖 Generated by [`frc-nix-update`](https://github.com/frc4451/frc-nix)