### PR TITLE
wpilib.firstdriverstation: init at 2027.0.0-alpha-4

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -32,4 +32,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: nix build -L '.#${{ matrix.attr }}'
+      - run: nix build --impure -L '.#${{ matrix.attr }}'
+        env:
+          NIXPKGS_ALLOW_UNFREE: 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Nix/NixOS
-result
+result*
 *.qcow2
 
 # Development

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ This repository includes automated package updates:
 ## Docs
 
 - [Why doesn't my Simulation GUI work?](/docs/simulation-gui.md)
+- [FIRST Driver Station (NixOS)](/docs/firstdriverstation.md)
 

--- a/docs/firstdriverstation.md
+++ b/docs/firstdriverstation.md
@@ -1,0 +1,9 @@
+# FIRST Driver Station (NixOS)
+
+To use the FIRST Driver Station you need your user to be in the input group and to add the package to the udev packages list.
+
+```nix
+{
+  services.udev.packages = [ pkgs.wpilib.firstdriverstation ];
+}
+```

--- a/docs/firstdriverstation.md
+++ b/docs/firstdriverstation.md
@@ -1,9 +1,29 @@
 # FIRST Driver Station (NixOS)
 
-To use the FIRST Driver Station you need your user to be in the input group and to add the package to the udev packages list.
+## App permissions
+
+To use the FIRST Driver Station you need your user to be in the input group:
+
+```nix
+users.users.alice.extraGroups = [ "input" ];
+```
+
+This allows it to access the keyboard for global input and E-Stop functionality.
+
+You can also install the udev rules from the documentation like so:
 
 ```nix
 {
   services.udev.packages = [ pkgs.wpilib.firstdriverstation ];
 }
+```
+
+However, it's currently unclear whether these udev rules are actually required, as the DS appears to work fine without them.
+
+## App Scaling
+
+The Driver Station uses the Avalonia framework, and runs through XWayland. On wayland with a HiDPI screen this might cause the app to be too small to be readable. The scaling of the app can be controlled by the `AVALONIA_GLOBAL_SCALE_FACTOR` variable:
+
+```nix
+environment.sessionVariables.AVALONIA_GLOBAL_SCALE_FACTOR = 2;
 ```

--- a/docs/firstdriverstation.md
+++ b/docs/firstdriverstation.md
@@ -1,8 +1,8 @@
 # FIRST Driver Station (NixOS)
 
-## App permissions
+## Permissions
 
-To use the FIRST Driver Station you need your user to be in the input group:
+Currently, in order to use the FIRST Driver Station on NixOS, you need your user to be in the input group:
 
 ```nix
 users.users.alice.extraGroups = [ "input" ];
@@ -13,16 +13,14 @@ This allows it to access the keyboard for global input and E-Stop functionality.
 You can also install the udev rules from the documentation like so:
 
 ```nix
-{
-  services.udev.packages = [ pkgs.wpilib.firstdriverstation ];
-}
+services.udev.packages = [ pkgs.wpilib.firstdriverstation ];
 ```
 
 However, it's currently unclear whether these udev rules are actually required, as the DS appears to work fine without them.
 
-## App Scaling
+## Scaling
 
-The Driver Station uses the Avalonia framework, and runs through XWayland. On wayland with a HiDPI screen this might cause the app to be too small to be readable. The scaling of the app can be controlled by the `AVALONIA_GLOBAL_SCALE_FACTOR` variable:
+The Driver Station uses the Avalonia framework, and runs through XWayland. On Wayland with a HiDPI screen this might cause the app to be too small to be readable. The scaling of the app can be controlled by the `AVALONIA_GLOBAL_SCALE_FACTOR` variable:
 
 ```nix
 environment.sessionVariables.AVALONIA_GLOBAL_SCALE_FACTOR = 2;

--- a/docs/firstdriverstation.md
+++ b/docs/firstdriverstation.md
@@ -10,13 +10,11 @@ users.users.alice.extraGroups = [ "input" ];
 
 This allows it to access the keyboard for global input and E-Stop functionality.
 
-You can also install the udev rules from the documentation like so:
+Some controllers might require your user to have access to `/dev/hidraw*` in order to use their full functionality. In this case, you can install the udev rules which give the active user read access to hidraw with the following:
 
 ```nix
 services.udev.packages = [ pkgs.wpilib.firstdriverstation ];
 ```
-
-However, it's currently unclear whether these udev rules are actually required, as the DS appears to work fine without them.
 
 ## Scaling
 

--- a/docs/firstdriverstation.md
+++ b/docs/firstdriverstation.md
@@ -25,3 +25,37 @@ The Driver Station uses the Avalonia framework, and runs through XWayland. On Wa
 ```nix
 environment.sessionVariables.AVALONIA_GLOBAL_SCALE_FACTOR = 2;
 ```
+
+## Dashboards
+
+You will need to configure a custom dashboard override for the driver station in order to use the elastic dashboard provided by frc-nix.
+
+First, add the elastic dashboard to your system packages:
+
+```nix
+environment.systemPackages = with pkgs; [ pkgs.elastic-dashboard ];
+```
+
+Then, create a file at `~/.firstds/DriverStationDashboardSettings.json` with the following content:
+
+```json
+{
+  "CustomDashboards": [
+    { "Name": "Elastic (NixOS)", "Executable": "/run/current-system/sw/bin/elastic_dashboard" }
+  ]
+}
+```
+
+Alternatively, this can also be done with Home Manager:
+
+```nix
+home.file.".firstds/DriverStationDashboardSettings.json".text = ''
+  {
+    "CustomDashboards": [
+      { "Name": "Elastic (NixOS)", "Executable": "${lib.getExe pkgs.elastic-dashboard}" }
+    ]
+  }
+'';
+```
+
+[Dashboard Settings Documentation](https://github.com/wpilibsuite/FirstDriverStation-Public/blob/main/docs/DashboardSettings.md)

--- a/docs/firstdriverstation.md
+++ b/docs/firstdriverstation.md
@@ -2,15 +2,19 @@
 
 ## Permissions
 
+### Input
+
 Currently, in order to use the FIRST Driver Station on NixOS, you need your user to be in the input group:
 
 ```nix
 users.users.alice.extraGroups = [ "input" ];
 ```
 
-This allows it to access the keyboard for global input and E-Stop functionality.
+This allows it access to the keyboard for global input and E-Stop functionality.
 
-Some controllers might require your user to have access to `/dev/hidraw*` in order to use their full functionality. In this case, you can install the udev rules which give the active user read access to hidraw with the following:
+### hidraw
+
+Some controllers require your user to have access to `/dev/hidraw*` in order to use their full functionality. (e.g. the touchpad on a PS5 DualSense controller.) In this case, you will need to install the udev rules which give the active user read access to `/dev/hidraw*`:
 
 ```nix
 services.udev.packages = [ pkgs.wpilib.firstdriverstation ];

--- a/pkgs/frc-nix-update/update-packages.sh
+++ b/pkgs/frc-nix-update/update-packages.sh
@@ -300,6 +300,14 @@ fetch_github_hashes() {
             hash=$(fetch_url_hash "$url")
             echo "hash = \"$hash\";"
             ;;
+        "FirstDriverStation")
+            local base_url="https://github.com/wpilibsuite/FirstDriverStation-Public/releases/download/v${version}"
+            local hash_x64 hash_arm64
+            hash_x64=$(fetch_url_hash "$base_url/FirstDriverStation-linux-x64-${version}.tar.gz")
+            hash_arm64=$(fetch_url_hash "$base_url/FirstDriverStation-linux-arm64-${version}.tar.gz")
+            echo "x86_64-linux = \"$hash_x64\";"
+            echo "aarch64-linux = \"$hash_arm64\";"
+            ;;
     esac
 }
 
@@ -417,6 +425,20 @@ update_hashes() {
                         if [[ -f "$docs_file" ]]; then
                             sed -i "s|npmDepsHash = \"[^\"]*\"|npmDepsHash = \"${BASH_REMATCH[1]}\"|" "$docs_file"
                         fi
+                    fi
+                done <<< "$hash_output"
+            elif [[ "$tool" == "FirstDriverStation" ]]; then
+                # FirstDriverStation: update per-arch hashes in sources block
+                while IFS= read -r hash_line; do
+                    if [[ "$hash_line" =~ ^([a-z0-9_-]+)\ =\ \"([^\"]+)\"\;$ ]]; then
+                        local arch="${BASH_REMATCH[1]}"
+                        local hash_val="${BASH_REMATCH[2]}"
+                        # Match the arch key in sources and update the following hash line
+                        awk -v arch="$arch" -v hash="$hash_val" '
+                        $0 ~ "\"" arch "\"" { found=1 }
+                        found && /hash = / { gsub(/hash = "[^"]*"/, "hash = \"" hash "\""); found=0 }
+                        { print }
+                        ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
                     fi
                 done <<< "$hash_output"
             else
@@ -599,6 +621,7 @@ update_all_packages() {
         ["pathplanner"]="mjansen4857/pathplanner:pkgs/pathplanner/package.nix:PathPlanner"
         ["vscode-wpilib"]="wpilibsuite/vscode-wpilib:pkgs/wpilib/vscode-wpilib.nix:vscode-wpilib"
         ["wpilib-utility"]="wpilibsuite/vscode-wpilib:pkgs/wpilib/wpilib-utility.nix:wpilib-utility"
+        ["firstdriverstation"]="wpilibsuite/FirstDriverStation-Public:pkgs/wpilib/firstdriverstation/package.nix:FirstDriverStation"
     )
 
     for package in "${!github_packages[@]}"; do

--- a/pkgs/wpilib/firstdriverstation/72-hidraw.rules
+++ b/pkgs/wpilib/firstdriverstation/72-hidraw.rules
@@ -1,0 +1,2 @@
+# Grant access to all hidraw devices for the active user
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0660", TAG+="uaccess"

--- a/pkgs/wpilib/firstdriverstation/package.nix
+++ b/pkgs/wpilib/firstdriverstation/package.nix
@@ -2,7 +2,9 @@
   lib,
   stdenv,
   autoPatchelfHook,
+  copyDesktopItems,
   fetchurl,
+  makeDesktopItem,
   udevCheckHook,
   makeBinaryWrapper,
 
@@ -59,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     udevCheckHook
   ];
 
@@ -116,6 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       install -Dm644 ./License.txt $out/share/doc/FirstDriverStation/License.txt
       install -Dm644 ${./72-hidraw.rules} $out/etc/udev/rules.d/72-hidraw.rules
+      install -Dm644 ${../wpilib_logo.svg} $out/share/icons/hicolor/scalable/apps/FirstDriverStation.svg
 
       makeBinaryWrapper ${installPath}/FirstDriverStation $out/bin/FirstDriverStation \
         --prefix PATH : ${lib.makeBinPath [ dhcpcd ]}
@@ -123,6 +127,24 @@ stdenv.mkDerivation (finalAttrs: {
       runHook postInstall
     '';
 
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "FirstDriverStation";
+      desktopName = name;
+      exec = name;
+      comment = finalAttrs.meta.description or null;
+      icon = name;
+      categories = [
+        "Robotics"
+        "Development"
+      ];
+      keywords = [
+        "FRC"
+        "FTC"
+        "DriverStation"
+      ];
+    })
+  ];
   meta = {
     description = "Enables users to control their FTC and FRC robots.";
     homepage = "https://github.com/wpilibsuite/FirstDriverStation-Public/";

--- a/pkgs/wpilib/firstdriverstation/package.nix
+++ b/pkgs/wpilib/firstdriverstation/package.nix
@@ -1,0 +1,141 @@
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  fetchurl,
+  udevCheckHook,
+  makeBinaryWrapper,
+
+  alsa-lib,
+  angle,
+  avahi,
+  fontconfig,
+  gtk3,
+  icu,
+  libGL,
+  libgcc,
+  libice,
+  libinput,
+  libpulseaudio,
+  libsm,
+  libusb1,
+  libx11,
+  libxcb,
+  libxcursor,
+  libxext,
+  libxfixes,
+  libxi,
+  libxrandr,
+  pipewire,
+  sndio,
+  udev,
+  webkitgtk_4_1,
+  dhcpcd,
+}:
+let
+  pname = "firstdriverstation";
+  version = "2027.0.0-alpha-2";
+
+  sourceURL = "https://github.com/wpilibsuite/FirstDriverStation-Public/releases/download/v${version}";
+  sources = {
+    "x86_64-linux" = fetchurl {
+      url = "${sourceURL}/FirstDriverStation-linux-x64-${version}.tar.gz";
+      hash = "sha256-MnDV6FQSYoPa3jQrXu+aD6UeNB9ZO4MtCHOqHTn5ei8=";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "${sourceURL}/FirstDriverStation-linux-arm64-${version}.tar.gz";
+      hash = "sha256-CZ5VAlCIyz0mA+IjpbqRSjdSoozomCfhs46txbKhdag=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
+
+  src =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    udevCheckHook
+  ];
+
+  buildInputs = [
+    makeBinaryWrapper
+
+    alsa-lib
+    angle
+    avahi
+    fontconfig
+    libGL
+    libgcc
+    libinput
+    libpulseaudio
+    libusb1
+    libx11
+    libxcb
+    libxcursor
+    libxext
+    libxfixes
+    libxi
+    libxrandr
+    pipewire
+    pipewire.jack
+    sndio
+    udev
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libGLES_CM.so.1"
+    "libsteam_api.so"
+  ];
+
+  runtimeDependencies = [
+    gtk3
+    icu
+    libice
+    libsm
+    libx11
+    webkitgtk_4_1
+  ];
+
+  dontBuild = true;
+
+  installPhase =
+    let
+      installPath = "$out/lib/wpilib/firstdriverstation";
+    in
+    ''
+      runHook preInstall
+
+      install -Dm744 ./FirstDriverStation ${installPath}/FirstDriverStation
+      install -Dm744 ./libHarfBuzzSharp.so ${installPath}/libHarfBuzzSharp.so
+      install -Dm744 ./libSkiaSharp.so ${installPath}/libSkiaSharp.so
+
+      install -Dm644 ./License.txt $out/share/doc/FirstDriverStation/License.txt
+      install -Dm644 ${./72-hidraw.rules} $out/etc/udev/rules.d/72-hidraw.rules
+
+      makeBinaryWrapper ${installPath}/FirstDriverStation $out/bin/FirstDriverStation \
+        --prefix PATH : ${lib.makeBinPath [ dhcpcd ]}
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Enables users to control their FTC and FRC robots.";
+    homepage = "https://github.com/wpilibsuite/FirstDriverStation-Public/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ nullcube ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      # TODO: Support darwin
+      # "x86_64-darwin"
+      # "aarch64-darwin"
+    ];
+    mainProgram = "FirstDriverStation";
+  };
+})

--- a/pkgs/wpilib/firstdriverstation/package.nix
+++ b/pkgs/wpilib/firstdriverstation/package.nix
@@ -11,6 +11,7 @@
   alsa-lib,
   angle,
   avahi,
+  dhcpcd,
   fontconfig,
   gtk3,
   icu,
@@ -28,25 +29,25 @@
   libxfixes,
   libxi,
   libxrandr,
+  openssl_legacy,
   pipewire,
   sndio,
   udev,
   webkitgtk_4_1,
-  dhcpcd,
 }:
 let
   pname = "firstdriverstation";
-  version = "2027.0.0-alpha-2";
+  version = "2027.0.0-alpha-3";
 
   sourceURL = "https://github.com/wpilibsuite/FirstDriverStation-Public/releases/download/v${version}";
   sources = {
     "x86_64-linux" = fetchurl {
       url = "${sourceURL}/FirstDriverStation-linux-x64-${version}.tar.gz";
-      hash = "sha256-MnDV6FQSYoPa3jQrXu+aD6UeNB9ZO4MtCHOqHTn5ei8=";
+      hash = "sha256-FiiE/YN1UImjh5DbOw/RH3lhoVZjU+HfTHw5zy9CgQQ=";
     };
     "aarch64-linux" = fetchurl {
       url = "${sourceURL}/FirstDriverStation-linux-arm64-${version}.tar.gz";
-      hash = "sha256-CZ5VAlCIyz0mA+IjpbqRSjdSoozomCfhs46txbKhdag=";
+      hash = "sha256-4nVYcrjjMRuz0GhjSi+6mRGG3ytmxQBxynUUtFCRCp4=";
     };
   };
 in
@@ -122,7 +123,8 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 ${../wpilib_logo.svg} $out/share/icons/hicolor/scalable/apps/FirstDriverStation.svg
 
       makeBinaryWrapper ${installPath}/FirstDriverStation $out/bin/FirstDriverStation \
-        --prefix PATH : ${lib.makeBinPath [ dhcpcd ]}
+        --prefix PATH : ${lib.makeBinPath [ dhcpcd ]} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ openssl_legacy ]}
 
       runHook postInstall
     '';

--- a/pkgs/wpilib/firstdriverstation/package.nix
+++ b/pkgs/wpilib/firstdriverstation/package.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
   desktopItems = [
     (makeDesktopItem rec {
       name = "FirstDriverStation";
-      desktopName = name;
+      desktopName = "FIRST Driver Station";
       exec = name;
       comment = finalAttrs.meta.description or null;
       icon = name;

--- a/pkgs/wpilib/firstdriverstation/package.nix
+++ b/pkgs/wpilib/firstdriverstation/package.nix
@@ -37,17 +37,17 @@
 }:
 let
   pname = "firstdriverstation";
-  version = "2027.0.0-alpha-3";
+  version = "2027.0.0-alpha-4";
 
   sourceURL = "https://github.com/wpilibsuite/FirstDriverStation-Public/releases/download/v${version}";
   sources = {
     "x86_64-linux" = fetchurl {
       url = "${sourceURL}/FirstDriverStation-linux-x64-${version}.tar.gz";
-      hash = "sha256-FiiE/YN1UImjh5DbOw/RH3lhoVZjU+HfTHw5zy9CgQQ=";
+      hash = "sha256-rS/6C0K72wenhdb6TG7O4icVraIaaoCkoxK7CSFldt4=";
     };
     "aarch64-linux" = fetchurl {
       url = "${sourceURL}/FirstDriverStation-linux-arm64-${version}.tar.gz";
-      hash = "sha256-4nVYcrjjMRuz0GhjSi+6mRGG3ytmxQBxynUUtFCRCp4=";
+      hash = "sha256-nAJSqGkf5LJvi+cznNrFMkHDhA87M3kJoeJ9/niQPyM=";
     };
   };
 in


### PR DESCRIPTION
Closes #70

Opening as draft because I'd like some testing to take place as well as fixing the couple bugs I have found so far.

Otherwise, the app seems to work great, joysticks show up, all the buttons seem to work, the log viewer works too. But of course I don't have a Systemcore to actually test it with.

## Issues:

~~Trying to set the dashboard to "Elastic" fails with the following line in the terminal:~~

```console
xdg-open: file '/home/nullcube/wpilib/2027_alpha4\elastic\elastic_dashboard' does not exist
```

~~I think this will have to be fixed upstream, the main solutions I can think of are either add a fallback to PATH for our special sauce case where we add `elastic_dashboard` to PATH, or adding a feature to allow people to define a custom path in the app.~~

~~Any thoughts?~~

(mostly) **Resolved by using a custom dashboard file entry:** https://github.com/nullcubee/frc-nix/blob/4ae1566e4a27f6f12c19e793723a9655ad76bc1d/docs/firstdriverstation.md#dashboards

***

~~"Renew DHCP Lease" button fails with the following error:~~
```console
dhclient failed, falling back to dhcpcd: An error occurred trying to start process 'dhclient' with working directory '/home/nullcube/git/frc-nix'. No such file or directory
read_config: /etc/dhcpcd.conf: No such file or directory
main: mkdir: /var/lib/dhcpcd: Permission denied
main: mkdir: /var/run/dhcpcd: Permission denied
main: pidfile_lock: /var/run/dhcpcd/pid: No such file or directory
Process 'dhcpcd -n' exited with code 1
```

~~This is a similar error to the one I get from just running `dhcpcd -n` as a normal user.~~

~~This is related to https://github.com/wpilibsuite/FirstDriverStation-Public/issues/3, except with dhcpcd instead.~~

~~Additionally, dhclient is deprecated and has been removed from nixpkgs and other distros:~~
https://salsa.debian.org/debian/isc-dhcp/-/merge_requests/5/diffs
https://www.isc.org/blogs/dhcp-client-relay-eom/

**This feature was removed:** https://github.com/wpilibsuite/FirstDriverStation-Public/issues/3#issuecomment-4403467338

***

`autoPatchelfHook` wants the libraries "`libGLES_CM.so.1`" and "`libsteam_api.so`" for the program, however I don't believe either of these are included in nixpkgs, and the program seems to work fine without them, so I've added them to the ignored list.

***

The driver station is coded such that it pulls `libHarfBuzzSharp.so` and `libSkiaSharp.so` in the local directory relative to the binary, and not from the conventional `LD_LIBRARY_PATH` as one would expect for `.so` files. I'm not sure if this is an actual issue or not, and if so it should be reported upstream.

As such I have had to place the binary in `$out/lib` and used `makeWrapper`, which isn't that big of a deal, but again, might be something that needs to be reported upstream.

Neither of these libs appear to be included in nixpkgs, except for in the outputs of other programs, such as `git-credential-manager`. I suspect this has something to do with the framework of the app, (it appears to be dotnet related) but I don't think I know enough to be sure.

## Things to test:

- [x] Does it work with Systemcore
- [x] ~~Input group shenanigans~~
- [ ] udev rules
- [x] E-Stop
- [ ] Ensure all the functions work as intended

Finally, as suggested, a module should probably be made for this for at least the udev rules if not also say network configuration stuff. The program does require avahi libs so I suspect that will need to be enabled for full functionality.

Please let me know any and all feedback, comments, and questions!
