### PR TITLE
advantagescope: fix build on latest nixpkgs

### DIFF
--- a/pkgs/advantagescope/package.nix
+++ b/pkgs/advantagescope/package.nix
@@ -89,10 +89,7 @@ buildNpmPackage (finalAttrs: {
     ;
 
   makeCacheWritable = true;
-  npmFlags = [
-    "--legacy-peer-deps"
-    "--ignore-scripts"
-  ];
+  npmFlags = [ "--ignore-scripts" ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/advantagescope/package.nix
+++ b/pkgs/advantagescope/package.nix
@@ -150,7 +150,13 @@ buildNpmPackage (finalAttrs: {
     description = "AdvantageScope is a robot diagnostics, log review/analysis, and data visualization application for FIRST teams developed by Team 6328";
     homepage = "https://docs.advantagescope.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ me-it-is ];
+    maintainers = [
+      {
+        name = "me-it-is";
+        github = "me-it-is";
+        githubId = "188520719";
+      }
+    ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"


### PR DESCRIPTION
Fixes #75 

removes `"--legacy-peer-deps"` from `npmFlags` as suggested by @TheFlameFish [here](https://github.com/frc4451/frc-nix/issues/75#issuecomment-4581503795).

Also resolves a failure when trying to evaluate the `meta.maintainers` field since @me-it-is is not in the nixpkgs [`maintainers-list.nix`](https://github.com/NixOS/nixpkgs/blob/57f0ba4fb845b3fde09c906cac0f32cb58e2051b/maintainers/maintainer-list.nix).