### PR TITLE
pathplanner: pin flutter341 and bump nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {

--- a/pkgs/pathplanner/package.nix
+++ b/pkgs/pathplanner/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  flutter,
+  flutter341,
   fetchFromGitHub,
   copyDesktopItems,
   stdenv,
@@ -8,7 +8,9 @@
   libuuid,
   makeDesktopItem,
 }:
-flutter.buildFlutterApplication rec {
+# pinned: pathplanner's pubspec.lock holds meta 1.16.0, and flutter >= 3.47
+# uses @awaitNotRequired from meta 1.17
+flutter341.buildFlutterApplication rec {
   pname = "pathplanner";
   version = "2026.1.2";
 


### PR DESCRIPTION
should fix #79; flutter needed to be pinned to a specific version as newer versions of flutter are incompatible with current pathplanner